### PR TITLE
feat: add contract storage helpers (get_storage, set_storage, remove_storage)

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -3,7 +3,8 @@ resolver = "2"
 
 members = [
     "chainverse-core",
-    "escrow"
+    "escrow",
+    "shared"
 ]
 
 [workspace.dependencies]

--- a/contracts/shared/Cargo.toml
+++ b/contracts/shared/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/shared/src/error.rs
+++ b/contracts/shared/src/error.rs
@@ -1,6 +1,4 @@
-#![no_std]
-
-use soroban_sdk::{contracterror};
+use soroban_sdk::contracterror;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/contracts/shared/src/events.rs
+++ b/contracts/shared/src/events.rs
@@ -1,6 +1,4 @@
-#![no_std]
-
-use soroban_sdk::{Env, Symbol, symbol_short,Address};
+use soroban_sdk::{Env, Symbol, symbol_short, Address};
 
 pub struct EventEmitter;
 pub const CERTIFICATE_MINTED: Symbol = symbol_short!("CertMint");
@@ -15,9 +13,9 @@ impl EventEmitter {
         amount: i128,
     ) {
         let topic = (
-            symbol_short!("chainverse"),
+            symbol_short!("chainvrs"),
             symbol_short!("course"),
-            symbol_short!("purchased"),
+            symbol_short!("purchase"),
         );
 
         env.events().publish(
@@ -34,7 +32,7 @@ impl EventEmitter {
         amount: i128,
     ) {
         let topic = (
-            symbol_short!("chainverse"),
+            symbol_short!("chainvrs"),
             symbol_short!("reward"),
             symbol_short!("claimed"),
         );
@@ -53,8 +51,8 @@ impl EventEmitter {
         token_id: u64,
     ) {
         let topic = (
-            symbol_short!("chainverse"),
-            symbol_short!("certificate"),
+            symbol_short!("chainvrs"),
+            symbol_short!("cert"),
             symbol_short!("minted"),
         );
 

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -2,6 +2,11 @@
 
 pub mod error;
 pub mod events;
+pub mod storage;
 
 pub use error::ContractError;
 pub use events::EventEmitter;
+pub use storage::{
+    get_instance_storage, get_persistent_storage, remove_instance_storage,
+    remove_persistent_storage, set_instance_storage, set_persistent_storage,
+};

--- a/contracts/shared/src/storage.rs
+++ b/contracts/shared/src/storage.rs
@@ -1,0 +1,161 @@
+use soroban_sdk::{Env, IntoVal, TryFromVal, Val};
+
+// ========================
+// Instance Storage Helpers
+// ========================
+
+/// Retrieves a value from instance storage by key.
+///
+/// Returns `None` if the key does not exist.
+pub fn get_instance_storage<K, V>(env: &Env, key: &K) -> Option<V>
+where
+    K: IntoVal<Env, Val>,
+    V: TryFromVal<Env, Val>,
+{
+    env.storage().instance().get(key)
+}
+
+/// Stores a key-value pair in instance storage.
+///
+/// Overwrites any existing value for the given key.
+pub fn set_instance_storage<K, V>(env: &Env, key: &K, val: &V)
+where
+    K: IntoVal<Env, Val>,
+    V: IntoVal<Env, Val>,
+{
+    env.storage().instance().set(key, val);
+}
+
+/// Removes a key and its associated value from instance storage.
+///
+/// No-op if the key does not exist.
+pub fn remove_instance_storage<K>(env: &Env, key: &K)
+where
+    K: IntoVal<Env, Val>,
+{
+    env.storage().instance().remove(key);
+}
+
+// ===========================
+// Persistent Storage Helpers
+// ===========================
+
+/// Retrieves a value from persistent storage by key.
+///
+/// Returns `None` if the key does not exist.
+pub fn get_persistent_storage<K, V>(env: &Env, key: &K) -> Option<V>
+where
+    K: IntoVal<Env, Val>,
+    V: TryFromVal<Env, Val>,
+{
+    env.storage().persistent().get(key)
+}
+
+/// Stores a key-value pair in persistent storage.
+///
+/// Overwrites any existing value for the given key.
+pub fn set_persistent_storage<K, V>(env: &Env, key: &K, val: &V)
+where
+    K: IntoVal<Env, Val>,
+    V: IntoVal<Env, Val>,
+{
+    env.storage().persistent().set(key, val);
+}
+
+/// Removes a key and its associated value from persistent storage.
+///
+/// No-op if the key does not exist.
+pub fn remove_persistent_storage<K>(env: &Env, key: &K)
+where
+    K: IntoVal<Env, Val>,
+{
+    env.storage().persistent().remove(key);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{symbol_short, Env};
+
+    // =====================
+    // Instance Storage Tests
+    // =====================
+
+    #[test]
+    fn test_instance_set_and_get() {
+        let env = Env::default();
+        let key = symbol_short!("MY_KEY");
+        set_instance_storage(&env, &key, &42u32);
+        let result: Option<u32> = get_instance_storage(&env, &key);
+        assert_eq!(result, Some(42u32));
+    }
+
+    #[test]
+    fn test_instance_get_nonexistent_returns_none() {
+        let env = Env::default();
+        let key = symbol_short!("MISSING");
+        let result: Option<u32> = get_instance_storage(&env, &key);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_instance_remove_clears_value() {
+        let env = Env::default();
+        let key = symbol_short!("DEL_KEY");
+        set_instance_storage(&env, &key, &99u32);
+        remove_instance_storage(&env, &key);
+        let result: Option<u32> = get_instance_storage(&env, &key);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_instance_set_overwrites_value() {
+        let env = Env::default();
+        let key = symbol_short!("OVR_KEY");
+        set_instance_storage(&env, &key, &10u32);
+        set_instance_storage(&env, &key, &20u32);
+        let result: Option<u32> = get_instance_storage(&env, &key);
+        assert_eq!(result, Some(20u32));
+    }
+
+    // ========================
+    // Persistent Storage Tests
+    // ========================
+
+    #[test]
+    fn test_persistent_set_and_get() {
+        let env = Env::default();
+        let key = symbol_short!("P_KEY");
+        set_persistent_storage(&env, &key, &42u32);
+        let result: Option<u32> = get_persistent_storage(&env, &key);
+        assert_eq!(result, Some(42u32));
+    }
+
+    #[test]
+    fn test_persistent_get_nonexistent_returns_none() {
+        let env = Env::default();
+        let key = symbol_short!("P_MISS");
+        let result: Option<u32> = get_persistent_storage(&env, &key);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_persistent_remove_clears_value() {
+        let env = Env::default();
+        let key = symbol_short!("P_DEL");
+        set_persistent_storage(&env, &key, &99u32);
+        remove_persistent_storage(&env, &key);
+        let result: Option<u32> = get_persistent_storage(&env, &key);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_persistent_set_overwrites_value() {
+        let env = Env::default();
+        let key = symbol_short!("P_OVR");
+        set_persistent_storage(&env, &key, &10u32);
+        set_persistent_storage(&env, &key, &20u32);
+        let result: Option<u32> = get_persistent_storage(&env, &key);
+        assert_eq!(result, Some(20u32));
+    }
+}


### PR DESCRIPTION
## Description
Add generic, reusable storage helper functions for instance and persistent
storage tiers in the shared crate. These helpers standardize storage access
across all contracts in the workspace.

## Related Issues
- Closes #73

## Changes Made
- Created `contracts/shared/Cargo.toml` to make the shared crate buildable
- Added `shared` to workspace members in `contracts/Cargo.toml`
- Created `contracts/shared/src/storage.rs` with 6 generic helpers:
  - `get_instance_storage<K, V>(&Env, &K) -> Option<V>`
  - `set_instance_storage<K, V>(&Env, &K, &V)`
  - `remove_instance_storage<K>(&Env, &K)`
  - `get_persistent_storage<K, V>(&Env, &K) -> Option<V>`
  - `set_persistent_storage<K, V>(&Env, &K, &V)`
  - `remove_persistent_storage<K>(&Env, &K)`
- Updated `contracts/shared/src/lib.rs` to declare and re-export the module
- Fixed pre-existing build blockers: removed invalid `#![no_std]` from module
  files and shortened `symbol_short!()` values exceeding the 9-char max

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
1. `cd contracts`
2. `cargo build -p shared`
3. `cargo test -p shared --features testutils` (requires Rust ≤1.84 due to
   pre-existing `stellar-xdr`/`arbitrary` version mismatch in lockfile)

## Checklist
- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
