### PR TITLE
feat: add reusable storage helper functions for contract storage operations (closes #73)

### DIFF
--- a/contracts/common/mod.rs
+++ b/contracts/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod storage;

--- a/contracts/common/storage.rs
+++ b/contracts/common/storage.rs
@@ -1,0 +1,30 @@
+use soroban_sdk::{Env, Symbol, TryFromVal, IntoVal, Val};
+
+/// Retrieves a value from instance storage by key.
+/// Returns `Option<T>` for missing values, avoiding panic.
+pub fn get_storage<T: TryFromVal<Env, Val>>(
+    env: &Env, 
+    key: &Symbol
+) -> Option<T> {
+    env.storage().instance().get(key)
+}
+
+/// Stores a value in instance storage associated with a key.
+/// Uses `IntoVal` trait for type-safe conversion to Soroban `Val`.
+pub fn set_storage<T: IntoVal<Env, Val>>(
+    env: &Env, 
+    key: &Symbol, 
+    value: &T
+) {
+    env.storage().instance().set(key, value);
+}
+
+/// Removes a key and its associated value from instance storage.
+pub fn remove_storage(env: &Env, key: &Symbol) {
+    env.storage().instance().remove(key);
+}
+
+/// Optional advanced helper to check if a key exists in instance storage.
+pub fn has_storage(env: &Env, key: &Symbol) -> bool {
+    env.storage().instance().has(key)
+}


### PR DESCRIPTION
## Add contract storage helpers

Closes #73

### Overview

This PR introduces reusable helper functions to simplify storage interactions across contracts.

---

### What’s included

- `get_storage` → safely retrieves values from contract storage  
- `set_storage` → stores values in contract storage  
- `remove_storage` → removes values from storage  

---

### Why

Storage interactions were previously repeated directly using:

```rust
env.storage().instance()
```
This leads to duplication and reduces readability.

These helpers provide a consistent and reusable abstraction layer.

### Implementation

- Created contracts/common/storage.rs
- Added generic helper functions with type safety
Designed to work across all contract modules