### PR TITLE
feat: add emergency pause mechanism across all Chainverse contracts

### DIFF
--- a/.kiro/specs/emergency-pause-mechanism/.config.kiro
+++ b/.kiro/specs/emergency-pause-mechanism/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "6fad7302-bb72-4f11-b84e-217414948710", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/emergency-pause-mechanism/requirements.md
+++ b/.kiro/specs/emergency-pause-mechanism/requirements.md
@@ -1,0 +1,104 @@
+# Requirements Document
+
+## Introduction
+
+The Emergency Pause Mechanism provides a unified, admin-controlled circuit breaker across all Chainverse smart contracts. When activated, the pause state blocks all critical state-mutating functions (escrow creation/release/cancellation, certificate minting, reward claiming, course purchases) while leaving read-only queries available. The mechanism must be consistent, auditable via on-chain events, and recoverable only by an authorized admin.
+
+## Glossary
+
+- **Admin**: The privileged address stored in each contract's configuration, authorized to invoke pause and unpause operations.
+- **Contract**: Any Chainverse Soroban smart contract (ChainverseCore, CertificateContract, EscrowContract, RewardContract, CourseRegistryContract).
+- **Critical_Function**: Any contract entry point that mutates state or transfers funds (e.g., `create_escrow`, `release_funds`, `refund_buyer`, `mint`, `claim_reward`, `upsert_course`).
+- **Pause_Guard**: The on-chain boolean flag (`Paused`) stored in instance storage that signals whether a contract is currently paused.
+- **ContractPaused**: The error code (value 6 per the shared error standard) returned when a Critical_Function is invoked while the Pause_Guard is active.
+- **Pause_Event**: The on-chain event emitted when a contract transitions to or from the paused state.
+- **Read_Only_Function**: Any contract entry point that only reads state without mutating it (e.g., `get_escrow`, `get_certificate`, `is_paused`, `get_config`).
+
+---
+
+## Requirements
+
+### Requirement 1: Admin-Only Pause Activation
+
+**User Story:** As an admin, I want to pause a contract in an emergency, so that I can prevent further state changes while investigating or mitigating an incident.
+
+#### Acceptance Criteria
+
+1. WHEN an admin invokes `pause` with a valid admin address, THE Contract SHALL set the Pause_Guard to `true`.
+2. WHEN a non-admin address invokes `pause`, THE Contract SHALL return `ContractError::Unauthorized` and leave the Pause_Guard unchanged.
+3. IF the contract has not been initialized, THEN THE Contract SHALL return `ContractError::NotInitialized` when `pause` is invoked.
+4. WHEN `pause` is invoked on an already-paused contract, THE Contract SHALL return successfully without error and the Pause_Guard SHALL remain `true`.
+
+---
+
+### Requirement 2: Admin-Only Unpause
+
+**User Story:** As an admin, I want to unpause a contract after an emergency is resolved, so that normal operations can resume.
+
+#### Acceptance Criteria
+
+1. WHEN an admin invokes `unpause` with a valid admin address, THE Contract SHALL set the Pause_Guard to `false`.
+2. WHEN a non-admin address invokes `unpause`, THE Contract SHALL return `ContractError::Unauthorized` and leave the Pause_Guard unchanged.
+3. IF the contract has not been initialized, THEN THE Contract SHALL return `ContractError::NotInitialized` when `unpause` is invoked.
+4. WHEN `unpause` is invoked on a contract that is not paused, THE Contract SHALL return successfully without error and the Pause_Guard SHALL remain `false`.
+
+---
+
+### Requirement 3: Critical Functions Blocked While Paused
+
+**User Story:** As a protocol operator, I want all state-mutating functions to be blocked when the contract is paused, so that no funds move and no state changes occur during an emergency.
+
+#### Acceptance Criteria
+
+1. WHILE the Pause_Guard is `true`, THE Contract SHALL return `ContractError::ContractPaused` for every Critical_Function invocation before any state mutation occurs.
+2. WHILE the Pause_Guard is `true`, THE Contract SHALL leave all on-chain state unchanged when a Critical_Function is invoked.
+3. WHILE the Pause_Guard is `true`, THE Contract SHALL permit Read_Only_Function invocations to succeed normally.
+4. WHEN the Pause_Guard transitions from `true` to `false`, THE Contract SHALL allow Critical_Function invocations to proceed normally.
+
+---
+
+### Requirement 4: Pause State Visibility
+
+**User Story:** As a developer or off-chain monitor, I want to query the current pause state of any contract, so that I can react to emergencies programmatically.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL expose an `is_paused` read-only function that returns `true` when the Pause_Guard is `true` and `false` otherwise.
+2. WHEN the contract has not been initialized, THE Contract SHALL return `false` from `is_paused` (defaulting to unpaused).
+3. THE Contract SHALL store the Pause_Guard in instance storage so that its value is consistent within a single ledger transaction.
+
+---
+
+### Requirement 5: On-Chain Pause and Unpause Events
+
+**User Story:** As an off-chain monitor or auditor, I want pause and unpause actions to emit on-chain events, so that I can detect and log emergency state transitions.
+
+#### Acceptance Criteria
+
+1. WHEN an admin successfully pauses a contract, THE Contract SHALL emit a Pause_Event with topic `chainverse:{domain}:paused` and payload `(admin: Address)`.
+2. WHEN an admin successfully unpauses a contract, THE Contract SHALL emit a Pause_Event with topic `chainverse:{domain}:unpaused` and payload `(admin: Address)`.
+3. IF `pause` or `unpause` returns an error, THEN THE Contract SHALL NOT emit a Pause_Event.
+
+---
+
+### Requirement 6: Consistent Pause Mechanism Across All Contracts
+
+**User Story:** As a developer, I want every Chainverse contract to implement the pause mechanism using the same interface and error codes, so that tooling and monitoring can treat all contracts uniformly.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL use `ContractError::ContractPaused` (error code 6) as defined in the shared error standard when blocking a Critical_Function.
+2. THE Contract SHALL implement `pause`, `unpause`, and `is_paused` entry points with identical signatures across ChainverseCore, CertificateContract, EscrowContract, RewardContract, and CourseRegistryContract.
+3. THE Contract SHALL store the Pause_Guard under the key `AdminKey::Paused` in instance storage, consistent with the existing ChainverseCore and CertificateContract implementations.
+
+---
+
+### Requirement 7: Pause State Persistence and Round-Trip Integrity
+
+**User Story:** As a developer, I want the pause state to persist correctly across ledger boundaries and be recoverable, so that the mechanism is reliable under all conditions.
+
+#### Acceptance Criteria
+
+1. WHEN a contract is paused and then unpaused, THE Contract SHALL allow Critical_Function invocations to succeed as if the contract had never been paused (round-trip property).
+2. WHEN a contract is paused, unpaused, and paused again, THE Contract SHALL correctly block Critical_Function invocations on the second pause.
+3. THE Contract SHALL preserve all existing escrow, certificate, and reward state unchanged across pause and unpause transitions.


### PR DESCRIPTION
## Summary

Implements a unified admin-controlled emergency pause mechanism across all Chainverse Soroban smart contracts (ChainverseCore, CertificateContract, EscrowContract, RewardContract, CourseRegistryContract).

## Changes

- Add `pause`, `unpause`, and `is_paused` entry points to EscrowContract, RewardContract, and CourseRegistryContract
- Store pause state under `AdminKey::Paused` in instance storage (consistent with existing ChainverseCore and CertificateContract)
- Block all critical state-mutating functions when paused, returning `ContractError::ContractPaused` (error code 6)
- Emit on-chain events (`chainverse:{domain}:paused` / `chainverse:{domain}:unpaused`) on state transitions
- Read-only functions remain accessible while paused

## Testing

- Admin-only access control for pause/unpause
- Critical functions blocked while paused, read-only functions unaffected
- Round-trip integrity: state preserved across pause/unpause cycles
- Consistent behavior across all 5 contracts


this pr Closes #51 
