### PR TITLE
[SC-16] Track total volume processed

### DIFF
--- a/contracts/escrow/src/create.rs
+++ b/contracts/escrow/src/create.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{token::Client as TokenClient, Address, Env};
 use crate::errors::EscrowError;
 use crate::events::escrow_created;
-use crate::storage::{is_token_whitelisted, next_escrow_id, save_escrow};
+use crate::storage::{add_to_total_volume, is_token_whitelisted, next_escrow_id, save_escrow};
 use crate::types::{Escrow, EscrowStatus};
 
 pub fn create_escrow(
@@ -38,6 +38,9 @@ pub fn create_escrow(
         expiration,
     };
     save_escrow(env, escrow_id, &escrow);
+
+    // Track total volume processed
+    add_to_total_volume(env, amount);
 
     // Emit event
     escrow_created(env, escrow_id, &buyer, &seller, amount);

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -55,6 +55,11 @@ impl EscrowContract {
         storage::load_escrow(&env, escrow_id).ok_or(EscrowError::NotFound)
     }
 
+    /// Returns the total token volume that has been deposited into escrow.
+    pub fn get_total_volume(env: Env) -> i128 {
+        storage::get_total_volume(&env)
+    }
+
     /// Returns the contract version string.
     pub fn version(env: Env) -> String {
         String::from_str(&env, version::CONTRACT_VERSION)
@@ -99,6 +104,23 @@ mod test {
         client.whitelist_token(&token_addr);
 
         (env, buyer, seller, token_addr, client)
+    }
+
+    // -----------------------------------------------------------------------
+    // get_total_volume
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_total_volume_increases_correctly() {
+        let (_, buyer, seller, token_addr, client) = setup(1000);
+
+        assert_eq!(client.get_total_volume(), 0);
+
+        client.create_escrow(&buyer, &seller, &token_addr, &300, &9000);
+        assert_eq!(client.get_total_volume(), 300);
+
+        client.create_escrow(&buyer, &seller, &token_addr, &200, &9000);
+        assert_eq!(client.get_total_volume(), 500);
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/escrow/src/storage.rs
+++ b/contracts/escrow/src/storage.rs
@@ -5,6 +5,7 @@ use crate::types::Escrow;
 pub enum DataKey {
     Escrow(u64),
     EscrowCount,
+    TotalVolume,
     WhitelistedToken(Address),
 }
 
@@ -38,4 +39,22 @@ pub fn whitelist_token(env: &Env, token: &Address) {
     env.storage()
         .instance()
         .set(&DataKey::WhitelistedToken(token.clone()), &true);
+}
+
+pub fn add_to_total_volume(env: &Env, amount: i128) {
+    let volume: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TotalVolume)
+        .unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&DataKey::TotalVolume, &(volume + amount));
+}
+
+pub fn get_total_volume(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalVolume)
+        .unwrap_or(0)
 }


### PR DESCRIPTION
## Summary

Tracks the cumulative token value deposited across all escrows via a `TotalVolume` storage counter.

## Changes

- **`storage.rs`**: Added `TotalVolume` key, `add_to_total_volume(amount)`, and `get_total_volume()` helpers
- **`create.rs`**: Calls `add_to_total_volume(amount)` after saving each new escrow
- **`lib.rs`**: Exposed `get_total_volume()` as a public contract function; added test verifying volume accumulates correctly

## Acceptance Criteria

- [x] Volume increases correctly

Closes #49