### PR TITLE
[SC-20] Prevent double escrow release

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -10,4 +10,5 @@ pub enum EscrowError {
     Unauthorized = 4,
     TokenNotAllowed = 5,
     NotExpired = 6,
+    AlreadyReleased = 7,
 }

--- a/contracts/escrow/src/events.rs
+++ b/contracts/escrow/src/events.rs
@@ -7,6 +7,13 @@ pub fn escrow_created(env: &Env, escrow_id: u64, buyer: &Address, seller: &Addre
     );
 }
 
+pub fn escrow_released(env: &Env, escrow_id: u64, seller: &Address, amount: i128) {
+    env.events().publish(
+        (symbol_short!("ESC_RLSD"),),
+        (escrow_id, seller.clone(), amount),
+    );
+}
+
 pub fn escrow_refunded(env: &Env, escrow_id: u64, buyer: &Address, amount: i128) {
     env.events().publish(
         (symbol_short!("ESC_RFND"),),

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -134,6 +134,18 @@ mod test {
         assert!(result.is_err(), "release after expiration must fail");
     }
 
+    #[test]
+    fn test_release_funds_fails_on_double_release() {
+        let (_env, buyer, seller, token_addr, client) = setup(1000);
+
+        let escrow_id = client.create_escrow(&buyer, &seller, &token_addr, &500, &9000);
+        client.release_funds(&escrow_id);
+
+        // Second release must be rejected with AlreadyReleased
+        let result = client.try_release_funds(&escrow_id);
+        assert!(result.is_err(), "double release must be rejected");
+    }
+
     // -----------------------------------------------------------------------
     // refund_buyer
     // -----------------------------------------------------------------------

--- a/contracts/escrow/src/release.rs
+++ b/contracts/escrow/src/release.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::{token::Client as TokenClient, Env};
 use crate::errors::EscrowError;
+use crate::events::escrow_released;
 use crate::storage::{load_escrow, save_escrow};
 use crate::types::EscrowStatus;
 
@@ -9,6 +10,11 @@ pub fn release_funds(env: &Env, escrow_id: u64) -> Result<(), EscrowError> {
 
     // Validate: only buyer can release funds to seller
     escrow.buyer.require_auth();
+
+    // Explicit guard: prevent double release
+    if escrow.status == EscrowStatus::Completed {
+        return Err(EscrowError::AlreadyReleased);
+    }
 
     // Validate: escrow must be in Pending state
     if escrow.status != EscrowStatus::Pending {
@@ -30,6 +36,9 @@ pub fn release_funds(env: &Env, escrow_id: u64) -> Result<(), EscrowError> {
     // Update status to Completed
     escrow.status = EscrowStatus::Completed;
     save_escrow(env, escrow_id, &escrow);
+
+    // Emit release event
+    escrow_released(env, escrow_id, &escrow.seller, escrow.amount);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds an explicit `AlreadyReleased` guard to `release_funds` so that a completed escrow cannot be paid out a second time, and emits a `ESC_RLSD` event on every successful release.

## Changes

- **`errors.rs`**: Added `AlreadyReleased = 7` variant to `EscrowError`
- **`release.rs`**: Added explicit `AlreadyReleased` check before the generic `NotPending` check; added `escrow_released` event emission on success
- **`events.rs`**: Added `escrow_released()` event helper
- **`lib.rs`**: Added `test_release_funds_fails_on_double_release` test

## Acceptance Criteria

- [x] Escrow cannot release twice

Closes #53