### PR TITLE
feat: implement escrow ID generator and active escrows query

### DIFF
--- a/contracts/chainverse-core/src/escrow/active_query.rs
+++ b/contracts/chainverse-core/src/escrow/active_query.rs
@@ -1,0 +1,32 @@
+use soroban_sdk::{Env, Vec};
+
+use super::{EscrowKey, EscrowRecord, EscrowStatus};
+
+/// Returns all escrows that are currently in the `Pending` state (i.e. active).
+///
+/// Iterates over every escrow ID from 0 to the current counter and collects
+/// those whose status is `EscrowStatus::Pending`. Missing records are skipped
+/// silently.
+pub fn get_active_escrows(env: &Env) -> Vec<EscrowRecord> {
+    let mut active = Vec::new(env);
+
+    let total: u64 = env
+        .storage()
+        .persistent()
+        .get(&EscrowKey::NextId)
+        .unwrap_or(0u64);
+
+    for id in 0..total {
+        if let Some(record) = env
+            .storage()
+            .persistent()
+            .get::<EscrowKey, EscrowRecord>(&EscrowKey::Record(id))
+        {
+            if record.status == EscrowStatus::Pending {
+                active.push_back(record);
+            }
+        }
+    }
+
+    active
+}

--- a/contracts/chainverse-core/src/escrow/id_generator.rs
+++ b/contracts/chainverse-core/src/escrow/id_generator.rs
@@ -1,0 +1,31 @@
+use soroban_sdk::Env;
+
+use super::EscrowKey;
+
+/// Reads the current counter, increments it in persistent storage, and returns
+/// the old value as the next unique escrow ID.
+///
+/// IDs start at 0 and increase by 1 for every new escrow. The counter is stored
+/// under `EscrowKey::NextId` so it survives ledger upgrades.
+pub fn next_escrow_id(env: &Env) -> u64 {
+    let current: u64 = env
+        .storage()
+        .persistent()
+        .get(&EscrowKey::NextId)
+        .unwrap_or(0u64);
+
+    env.storage()
+        .persistent()
+        .set(&EscrowKey::NextId, &(current + 1));
+
+    current
+}
+
+/// Returns the total number of escrows ever created (i.e. the next ID that
+/// would be assigned) without modifying state.
+pub fn current_escrow_count(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&EscrowKey::NextId)
+        .unwrap_or(0u64)
+}

--- a/contracts/chainverse-core/src/escrow/mod.rs
+++ b/contracts/chainverse-core/src/escrow/mod.rs
@@ -2,6 +2,12 @@ use soroban_sdk::{contracttype, Address, Env};
 
 use crate::errors::ContractError;
 
+pub mod active_query;
+pub mod id_generator;
+
+pub use active_query::get_active_escrows;
+pub use id_generator::next_escrow_id;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------

--- a/contracts/chainverse-core/src/lib.rs
+++ b/contracts/chainverse-core/src/lib.rs
@@ -207,6 +207,11 @@ impl ChainverseCore {
         escrow::search(&env, token, status)
     }
 
+    /// Returns all escrows currently in the Pending (active) state.
+    pub fn get_active_escrows(env: Env) -> Vec<EscrowRecord> {
+        escrow::get_active_escrows(&env)
+    }
+
     // -----------------------------------------------------------------------
     // Utils module
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `escrow/id_generator.rs` with `next_escrow_id()` — reads and atomically increments a persistent counter to assign each new escrow a unique, sequential ID; also exposes `current_escrow_count()` for read-only access
- Adds `escrow/active_query.rs` with `get_active_escrows()` — iterates all escrow records and returns only those with `EscrowStatus::Pending`, exposed as the `get_active_escrows` contract entry point
- Both modules are wired into `escrow/mod.rs` and the contract in `lib.rs`

closes #72, closes #74