### PR TITLE
Resolve escrow undefined function, vault token transfer, cancel,…

### DIFF
--- a/contracts/escrow-vault/src/lib.rs
+++ b/contracts/escrow-vault/src/lib.rs
@@ -67,15 +67,20 @@ impl EscrowVault {
         depositor.require_auth();
         let id = Self::next_id(&env);
         let vault = Vault {
-            depositor,
+            depositor: depositor.clone(),
             recipient,
-            token,
+            token: token.clone(),
             amount,
             approvers,
             approvals: Vec::new(&env),
             status: VaultStatus::Pending,
         };
-        env.storage().instance().set(&DataKey::Vault(id), &vault);
+        env.storage().persistent().set(&DataKey::Vault(id), &vault);
+
+        // Pull funds from depositor into the contract
+        soroban_sdk::token::Client::new(&env, &token)
+            .transfer(&depositor, &env.current_contract_address(), &amount);
+
         id
     }
 
@@ -86,7 +91,7 @@ impl EscrowVault {
 
         let mut vault: Vault = env
             .storage()
-            .instance()
+            .persistent()
             .get(&DataKey::Vault(vault_id))
             .ok_or(VaultError::NotFound)?;
 
@@ -109,18 +114,43 @@ impl EscrowVault {
         // Release when all approvers have signed off
         if vault.approvals.len() == vault.approvers.len() {
             vault.status = VaultStatus::Released;
+            soroban_sdk::token::Client::new(&env, &vault.token)
+                .transfer(&env.current_contract_address(), &vault.recipient, &vault.amount);
         }
 
-        env.storage().instance().set(&DataKey::Vault(vault_id), &vault);
+        env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
         Ok(())
     }
 
     /// Returns the vault record for the given id.
     pub fn get_vault(env: Env, vault_id: u64) -> Result<Vault, VaultError> {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::Vault(vault_id))
             .ok_or(VaultError::NotFound)
+    }
+
+    /// Cancel a pending vault and return funds to the depositor.
+    pub fn cancel_vault(env: Env, vault_id: u64) -> Result<(), VaultError> {
+        let mut vault: Vault = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vault(vault_id))
+            .ok_or(VaultError::NotFound)?;
+
+        vault.depositor.require_auth();
+
+        if vault.status != VaultStatus::Pending {
+            return Err(VaultError::NotPending);
+        }
+
+        // Return funds to depositor
+        soroban_sdk::token::Client::new(&env, &vault.token)
+            .transfer(&env.current_contract_address(), &vault.depositor, &vault.amount);
+
+        vault.status = VaultStatus::Cancelled;
+        env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
+        Ok(())
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/escrow/src/refund.rs
+++ b/contracts/escrow/src/refund.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{token::Client as TokenClient, Env};
 use crate::errors::EscrowError;
 use crate::events::escrow_refunded;
-use crate::storage::{decrement_active_escrows, load_escrow, save_escrow};
+use crate::storage::{load_escrow, save_escrow};
 use crate::types::EscrowStatus;
 
 pub fn refund_buyer(env: &Env, escrow_id: u64) -> Result<(), EscrowError> {
@@ -31,7 +31,6 @@ pub fn refund_buyer(env: &Env, escrow_id: u64) -> Result<(), EscrowError> {
     // Update status to Cancelled
     escrow.status = EscrowStatus::Cancelled;
     save_escrow(env, escrow_id, &escrow);
-    decrement_active_escrows(env);
 
     // Emit event
     escrow_refunded(env, escrow_id, &escrow.buyer, escrow.amount);

--- a/contracts/escrow/src/release.rs
+++ b/contracts/escrow/src/release.rs
@@ -4,6 +4,7 @@ use crate::events::escrow_released;
 use crate::storage::{load_escrow, save_escrow};
 use crate::types::EscrowStatus;
 
+
 pub fn release_funds(env: &Env, escrow_id: u64) -> Result<(), EscrowError> {
     // Load escrow, return NotFound if missing
     let mut escrow = load_escrow(env, escrow_id).ok_or(EscrowError::NotFound)?;
@@ -36,13 +37,9 @@ pub fn release_funds(env: &Env, escrow_id: u64) -> Result<(), EscrowError> {
     // Update status to Completed
     escrow.status = EscrowStatus::Completed;
     save_escrow(env, escrow_id, &escrow);
-    decrement_active_escrows(env);
 
     // Emit release event
     escrow_released(env, escrow_id, &escrow.seller, escrow.amount);
-
-    // Emit event
-    escrow_completed(env, escrow_id, &escrow.buyer, &escrow.seller, escrow.amount);
 
     Ok(())
 }


### PR DESCRIPTION
closes #219
closes #229
closes #230
closes #231


## Summary

This PR addresses four bugs in the `escrow` and `escrow-vault` contracts that would cause compilation failures, permanent fund loss, and incorrect storage behavior in production. None of these issues were caught by existing tests because the affected code paths either failed to compile or lacked coverage.

---

## Problem 1 — `release.rs` and `refund.rs`: calls to undefined `decrement_active_escrows`

Both `release.rs` (line 39) and `refund.rs` (line 26) called `decrement_active_escrows(env)`, a function that does not exist anywhere in `storage.rs` or any other module. This would cause a compilation error, making the entire contract undeployable.

Additionally, `release.rs` called `escrow_completed(...)` which is also undefined — this was a leftover from a refactor that was never cleaned up.

**Fix:** Removed both calls from `release.rs` and `refund.rs`. Removed the unused `decrement_active_escrows` import from `refund.rs`. The escrow status is still correctly updated to `Completed` or `Cancelled` via `save_escrow`, so no functional behavior is lost.

---

## Problem 2 — `escrow-vault/lib.rs`: `create_vault` never transfers tokens into the contract

`create_vault` accepted a `token` and `amount`, stored the vault record, and returned the vault ID — but never actually moved any funds. A depositor calling this function would have their vault created on-chain with no tokens backing it. Any subsequent `approve_release` would then attempt to transfer funds the contract does not hold, causing a runtime failure.

**Fix:** Added a `TokenClient::transfer` call at the end of `create_vault` that pulls `amount` of `token` from the `depositor` into `env.current_contract_address()`. The `depositor.require_auth()` already present ensures the transfer is authorized.

---

## Problem 3 — `escrow-vault/lib.rs`: no way for a depositor to cancel a vault

Once a vault was created, there was no exit path for the depositor if approvers became unresponsive, went offline, or simply never acted. Funds would be locked in the contract indefinitely with no recovery mechanism.

**Fix:** Added a `cancel_vault(env, vault_id)` function that:
- Loads the vault, returning `NotFound` if it doesn't exist
- Calls `depositor.require_auth()` to ensure only the original depositor can cancel
- Returns `NotPending` if the vault has already been released or cancelled
- Transfers the full `amount` back to the `depositor` via `TokenClient::transfer`
- Sets the vault status to `Cancelled` and persists the update

---

## Problem 4 — `escrow-vault/lib.rs`: vault records stored in instance storage

All `DataKey::Vault` reads and writes used `env.storage().instance()`. Instance storage in Soroban is intended for small, contract-level configuration data and has strict size limits. Storing an unbounded number of vault records there would cause the contract to hit storage limits as usage grows, breaking vault creation for all users.

**Fix:** Replaced all `env.storage().instance().set/get` calls for `DataKey::Vault` with `env.storage().persistent().set/get`. Persistent storage is designed for long-lived, per-record data and is the correct choice here. The `NextId` counter remains in instance storage as it is a single small value.

---

## Additional fix — `approve_release` never transferred funds on release

Related to Problem 2: even after the approval threshold was met and `vault.status` was set to `Released`, no token transfer to the recipient was executed. The vault would be marked released but the recipient would never receive funds.

**Fix:** Added a `TokenClient::transfer` call inside `approve_release` when `vault.approvals.len() == vault.approvers.len()`, transferring `amount` from the contract to `vault.recipient`.

---

## Files Changed

| File | Change |
|---|---|
| `contracts/escrow/src/release.rs` | Removed call to undefined `decrement_active_escrows` and `escrow_completed` |
| `contracts/escrow/src/refund.rs` | Removed call to and import of undefined `decrement_active_escrows` |
| `contracts/escrow-vault/src/lib.rs` | Token transfer on create, token transfer on release, `cancel_vault` function, persistent storage for vault records |
