### PR TITLE
fix: resolve issues #232, #233, #234, #236

### DIFF
--- a/contracts/certificates/src/lib.rs
+++ b/contracts/certificates/src/lib.rs
@@ -23,6 +23,7 @@ impl CertificateContract {
             return Err(ContractError::AlreadyInitialized);
         }
 
+        // The deployer must sign to prove they control the intended admin address.
         admin.require_auth();
         storage::set_admin(&env, &admin);
         storage::set_paused(&env, false);
@@ -32,6 +33,7 @@ impl CertificateContract {
     pub fn toggle_pause(env: Env, caller: Address, paused: bool) -> Result<(), ContractError> {
         storage::require_admin(&env, &caller)?;
         storage::set_paused(&env, paused);
+        env.events().publish((symbol_short!("paused"),), paused);
         Ok(())
     }
 

--- a/contracts/certificates/src/storage.rs
+++ b/contracts/certificates/src/storage.rs
@@ -59,9 +59,12 @@ pub fn load_certificate(env: &Env, wallet: &Address, course_id: u64) -> Option<C
         .get(&DataKey::Certificate(wallet.clone(), course_id))
 }
 
+// ~1 year expressed in ledger entries (5-second close time)
+const MIN_TTL: u32 = 3_110_400;
+const MAX_TTL: u32 = 6_220_800;
+
 pub fn save_certificate(env: &Env, wallet: &Address, course_id: u64, certificate: &Certificate) {
-    env.storage().persistent().set(
-        &DataKey::Certificate(wallet.clone(), course_id),
-        certificate,
-    );
+    let key = DataKey::Certificate(wallet.clone(), course_id);
+    env.storage().persistent().set(&key, certificate);
+    env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL);
 }

--- a/contracts/escrow-vault/src/lib.rs
+++ b/contracts/escrow-vault/src/lib.rs
@@ -65,6 +65,9 @@ impl EscrowVault {
         approvers: Vec<Address>,
     ) -> u64 {
         depositor.require_auth();
+        if approvers.is_empty() {
+            panic!("approvers list cannot be empty");
+        }
         let id = Self::next_id(&env);
         let vault = Vault {
             depositor: depositor.clone(),


### PR DESCRIPTION
## Summary

Fixes four smart-contract issues in a single PR.

### Changes

- **#232** `escrow-vault/src/lib.rs`: Added empty-approvers guard at the top of `create_vault` — panics if `approvers` is empty, preventing vaults that can never be released.
- **#233** `certificates/src/storage.rs`: Added `extend_ttl` after every `set` in `save_certificate`, with `MIN_TTL`/`MAX_TTL` constants (~1 year in ledger entries) to prevent certificate eviction.
- **#234** `certificates/src/lib.rs`: Emits a `paused` event inside `toggle_pause` so off-chain indexers can track pause-state changes without polling.
- **#236** `certificates/src/lib.rs`: Added inline comment above `admin.require_auth()` in `init` explaining why the deployer must sign before the admin is set.

Closes #232
Closes #233
Closes #234
Closes #236