### PR TITLE
fix: enforce auth on initialize, propagate errors in course registry, and emit payout events

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -746,6 +746,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "payout-automation"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "chainverse-core",
     "course_registry",
     "escrow",
+    "payout-automation",
     "shared"
 ]
 

--- a/contracts/chainverse-core/src/lib.rs
+++ b/contracts/chainverse-core/src/lib.rs
@@ -52,6 +52,8 @@ impl ChainverseCore {
         protocol_fee: u32,
         supported_tokens: Vec<Address>,
     ) -> Result<(), ContractError> {
+        admin.require_auth();
+
         if env.storage().persistent().has(&DataKey::Config) {
             return Err(ContractError::AlreadyInitialized);
         }

--- a/contracts/course_registry/src/lib.rs
+++ b/contracts/course_registry/src/lib.rs
@@ -12,6 +12,8 @@ pub enum ContractError {
     NotAdmin = 1,
     CourseNotFound = 2,
     CourseInactive = 3,
+    AlreadyInitialized = 4,
+    NotInitialized = 5,
 }
 
 // Storage Keys
@@ -40,23 +42,25 @@ pub struct CourseRegistryContract;
 impl CourseRegistryContract {
 
     // Initialize Admin (run once)
-    pub fn initialize(env: Env, admin: Address) {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("Already initialized");
+            return Err(ContractError::AlreadyInitialized);
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
     }
 
     // Internal Admin Check
-    fn require_admin(env: &Env) {
+    fn require_admin(env: &Env) -> Result<(), ContractError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .unwrap();
+            .ok_or(ContractError::NotInitialized)?;
 
         admin.require_auth();
+        Ok(())
     }
 
     // Add or Update Course
@@ -66,8 +70,8 @@ impl CourseRegistryContract {
         price_xlm: i128,
         price_chv: i128,
         is_active: bool,
-    ) {
-        Self::require_admin(&env);
+    ) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
 
         // Validate: prices must be non-negative
         if price_xlm < 0 || price_chv < 0 {
@@ -84,6 +88,7 @@ impl CourseRegistryContract {
         env.storage()
             .persistent()
             .set(&DataKey::Course(course_id), &course);
+        Ok(())
     }
 
     // Toggle Course Activation
@@ -91,8 +96,8 @@ impl CourseRegistryContract {
         env: Env,
         course_id: Symbol,
         is_active: bool,
-    ) {
-        Self::require_admin(&env);
+    ) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
 
         let key = DataKey::Course(course_id.clone());
 
@@ -106,11 +111,12 @@ impl CourseRegistryContract {
         course.is_active = is_active;
 
         env.storage().persistent().set(&key, &course);
+        Ok(())
     }
 
     // Deactivate Course
-    pub fn deactivate_course(env: Env, course_id: Symbol) {
-        Self::require_admin(&env);
+    pub fn deactivate_course(env: Env, course_id: Symbol) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
 
         let key = DataKey::Course(course_id.clone());
 
@@ -122,6 +128,7 @@ impl CourseRegistryContract {
         course.is_active = false;
 
         env.storage().persistent().set(&key, &course);
+        Ok(())
     }
 
 

--- a/contracts/payout-automation/src/lib.rs
+++ b/contracts/payout-automation/src/lib.rs
@@ -3,7 +3,7 @@
 use soroban_sdk::{
     contract, contractimpl, contracttype, contracterror,
     token::Client as TokenClient,
-    Address, Env, Vec,
+    symbol_short, Address, Env, Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -80,13 +80,22 @@ impl PayoutAutomation {
         }
 
         let token_client = TokenClient::new(&env, &token);
+        let mut total_amount: i128 = 0;
+        let mut recipient_count: u32 = 0;
         for entry in payouts.iter() {
             token_client.transfer(
                 &env.current_contract_address(),
                 &entry.recipient,
                 &entry.amount,
             );
+            total_amount += entry.amount;
+            recipient_count += 1;
         }
+
+        env.events().publish(
+            (symbol_short!("payout"), symbol_short!("executed")),
+            (caller, token, total_amount, recipient_count),
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- **#248** (`chainverse-core`): Added `admin.require_auth()` before the already-initialized guard in `initialize()` so callers cannot front-run initialization without admin authorization.
- **#253** (`course_registry`): Added `AlreadyInitialized = 4` and `NotInitialized = 5` to `ContractError`; replaced `panic!("Already initialized")` in `initialize()` with `return Err(ContractError::AlreadyInitialized)`.
- **#254** (`course_registry`): Changed `require_admin()` from an infallible function that calls `.unwrap()` to `Result<(), ContractError>` using `.ok_or(ContractError::NotInitialized)?`; updated all callers (`upsert_course`, `toggle_course`, `deactivate_course`) to propagate the result.
- **#246** (`payout-automation`): Emit a `(payout, executed)` event after the transfer loop carrying `caller`, `token`, `total_amount`, and `recipient_count`. Also added `payout-automation` to the workspace members — it was referencing `workspace = true` dependencies but was not listed, causing build failures.

## Test plan

- [ ] `cargo test -p course_registry` — initialize twice returns `AlreadyInitialized`, non-admin returns `Unauthorized`
- [ ] `cargo test -p chainverse-core` — double initialize returns `AlreadyInitialized`, unauthorized initialize is rejected
- [ ] `cargo test -p payout-automation` — all 3 existing tests pass; event is emitted after batch execution

Closes #246 Closes #248 Closes #253 Closes #254