### PR TITLE
fix: resolve issues #242 #243 #245 #247

### DIFF
--- a/contracts/payout-automation/src/lib.rs
+++ b/contracts/payout-automation/src/lib.rs
@@ -64,6 +64,14 @@ impl PayoutAutomation {
         Ok(())
     }
 
+    /// Admin-only: remove an address from the authorised set.
+    pub fn remove_authorised(env: Env, admin: Address, caller: Address) -> Result<(), PayoutError> {
+        admin.require_auth();
+        Self::only_admin(&env, &admin)?;
+        env.storage().instance().remove(&DataKey::Authorised(caller));
+        Ok(())
+    }
+
     /// Execute a batch payout. The caller must be in the authorised set.
     /// Transfers `token` from the contract to each recipient in `payouts`.
     /// An empty batch is accepted gracefully (no-op).
@@ -83,6 +91,9 @@ impl PayoutAutomation {
         let mut total_amount: i128 = 0;
         let mut recipient_count: u32 = 0;
         for entry in payouts.iter() {
+            if entry.amount <= 0 {
+                continue;
+            }
             token_client.transfer(
                 &env.current_contract_address(),
                 &entry.recipient,

--- a/contracts/reward/src/admin.rs
+++ b/contracts/reward/src/admin.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{Env, Address};
-use crate::storage::DataKey;
+use crate::DataKey;
 use crate::errors::Error;
 
 pub fn require_admin(env: &Env) -> Result<Address, Error> {
@@ -8,7 +8,6 @@ pub fn require_admin(env: &Env) -> Result<Address, Error> {
         .instance()
         .get(&DataKey::Admin)
         .ok_or(Error::Unauthorized)?;
-
     admin.require_auth();
     Ok(admin)
 }

--- a/contracts/reward/src/errors.rs
+++ b/contracts/reward/src/errors.rs
@@ -3,16 +3,8 @@ use soroban_sdk::contracterror;
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
-    Unauthorized = 1,
-    InvalidSignature = 2,
-}
-
-use soroban_sdk::contracttype;
-
-#[derive(Clone)]
-#[contracttype]
-pub enum RewardError {
-    SignatureExpired = 1,
-    NonceAlreadyUsed = 2,
-    InvalidSignature = 3,
+    Unauthorized       = 1,
+    InvalidSignature   = 2,
+    AlreadyInitialized = 3,
+    AlreadyRewarded    = 4,
 }

--- a/contracts/reward/src/lib.rs
+++ b/contracts/reward/src/lib.rs
@@ -1,18 +1,28 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Env, BytesN,Address};
-use reward::claim_reward;
-use crate::admin::require_admin;
-use crate::storage::DataKey;
-use crate::errors::Error;
+use soroban_sdk::{contract, contractimpl, contracttype, Env, BytesN, Address};
+
 mod storage;
-use storage::DataKey;
 mod signature;
-use signature::build_message;
 mod errors;
-use errors::RewardError;
 mod reward;
 mod events;
+mod admin;
+mod crypto;
+
+use storage::{set_treasury, set_token, set_reward_amount};
+use admin::require_admin;
+use errors::Error;
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Initialized,
+    BackendPubKey,
+    BackendSigner,
+    UsedNonce(BytesN<32>),
+}
 
 #[contract]
 pub struct RewardContract;
@@ -20,42 +30,44 @@ pub struct RewardContract;
 #[contractimpl]
 impl RewardContract {
 
+    /// One-time initialisation. Sets admin, treasury, token, and reward amount.
+    /// Reverts if already initialised.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        treasury: Address,
+        token: Address,
+        reward_amount: i128,
+    ) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        set_treasury(&env, &treasury);
+        set_token(&env, &token);
+        set_reward_amount(&env, reward_amount);
+        env.storage().instance().set(&DataKey::Initialized, &true);
+        Ok(())
+    }
+
     pub fn set_backend_pubkey(env: Env, pubkey: BytesN<32>) -> Result<(), Error> {
         require_admin(&env)?;
-
-        env.storage()
-            .instance()
-            .set(&DataKey::BackendPubKey, &pubkey);
-
+        env.storage().instance().set(&DataKey::BackendPubKey, &pubkey);
         Ok(())
     }
 
     pub fn rotate_backend_pubkey(env: Env, new_pubkey: BytesN<32>) -> Result<(), Error> {
         require_admin(&env)?;
-
-        env.storage()
-            .instance()
-            .set(&DataKey::BackendPubKey, &new_pubkey);
-
+        env.storage().instance().set(&DataKey::BackendPubKey, &new_pubkey);
         Ok(())
     }
 
     pub fn get_backend_pubkey(env: Env) -> Option<BytesN<32>> {
-        env.storage()
-            .instance()
-            .get(&DataKey::BackendPubKey)
+        env.storage().instance().get(&DataKey::BackendPubKey)
     }
 
-    pub fn claim_reward(env: Env, user: Address) -> Result<(), errors::ContractError> {
-        claim_reward(env, user)
+    pub fn claim_reward(env: Env, user: Address) -> Result<(), errors::Error> {
+        reward::claim_reward(env, user)
     }
-}
-
-use soroban_sdk::{contracttype, BytesN};
-
-#[derive(Clone)]
-#[contracttype]
-pub enum DataKey {
-    BackendSigner,
-    UsedNonce(BytesN<32>),
 }

--- a/contracts/reward/src/reward.rs
+++ b/contracts/reward/src/reward.rs
@@ -1,34 +1,23 @@
 use soroban_sdk::{Env, Address, token::Client};
 use crate::storage::*;
 use crate::events::*;
-use shared::errors::ContractError;
+use crate::errors::Error;
 
-pub fn claim_reward(env: Env, user: Address) -> Result<(), ContractError> {
+pub fn claim_reward(env: Env, user: Address) -> Result<(), Error> {
     user.require_auth();
 
-    // 1️⃣ Check not already rewarded
     if has_been_rewarded(&env, &user) {
-        return Err(ContractError::AlreadyRewarded);
+        return Err(Error::AlreadyRewarded);
     }
 
-    // 2️⃣ Get reward details
     let treasury = get_treasury(&env);
     let token_address = get_token(&env);
     let reward_amount = get_reward_amount(&env);
 
-    // 3️⃣ Transfer from treasury to user
     let token_client = Client::new(&env, &token_address);
+    token_client.transfer(&treasury, &user, &reward_amount);
 
-    token_client.transfer(
-        &treasury,
-        &user,
-        &reward_amount,
-    );
-
-    // 4️⃣ Mark as rewarded
     set_rewarded(&env, &user);
-
-    // 5️⃣ Emit event
     emit_reward_claimed(&env, &user, reward_amount);
 
     Ok(())

--- a/contracts/reward/src/storage.rs
+++ b/contracts/reward/src/storage.rs
@@ -6,11 +6,11 @@ const TOKEN: soroban_sdk::Symbol = symbol_short!("TOKEN");
 const REWARD_AMOUNT: soroban_sdk::Symbol = symbol_short!("REWARD_AMT");
 
 pub fn has_been_rewarded(env: &Env, user: &Address) -> bool {
-    env.storage().instance().get(&(REWARDED, user)).unwrap_or(false)
+    env.storage().persistent().get(&(REWARDED, user)).unwrap_or(false)
 }
 
 pub fn set_rewarded(env: &Env, user: &Address) {
-    env.storage().instance().set(&(REWARDED, user), &true);
+    env.storage().persistent().set(&(REWARDED, user), &true);
 }
 
 pub fn set_treasury(env: &Env, treasury: &Address) {


### PR DESCRIPTION
## Summary

Close  #242,  Closes #243, Closes #245, Close #247 

### #242 — reward/src/storage.rs: persistent storage for REWARDED flag
`has_been_rewarded` and `set_rewarded` now use `env.storage().persistent()` so user reward records survive contract upgrades/re-deployments.

### #243 — reward/src/lib.rs: initialize() with re-init guard
Added `initialize(env, admin, treasury, token, reward_amount)` that sets all values atomically and returns `Error::AlreadyInitialized` if called again. `DataKey` enum extended with `Admin` and `Initialized` variants.

### #245 — payout-automation/src/lib.rs: remove_authorised
Added `remove_authorised(env, admin, caller)` mirroring `add_authorised`, so compromised authorised keys can be revoked.

### #247 — payout-automation/src/lib.rs: validate payout amount > 0
Added `if entry.amount <= 0 { continue; }` guard inside the execute loop to skip zero/negative entries and avoid wasting compute budget on no-op transfers.