### PR TITLE
fix: re-init guard, duplicate DataKey, TTL bumps, revoke_certificate

### DIFF
--- a/contracts/certificates/src/errors.rs
+++ b/contracts/certificates/src/errors.rs
@@ -11,4 +11,5 @@ pub enum ContractError {
     CertificateExists = 5,
     InvalidProof = 6,
     SoulboundTransferNotAllowed = 7,
+    CertificateNotFound = 8,
 }

--- a/contracts/certificates/src/lib.rs
+++ b/contracts/certificates/src/lib.rs
@@ -12,6 +12,7 @@ pub use errors::ContractError;
 pub use types::Certificate;
 
 use soroban_sdk::{contract, contractimpl, symbol_short, xdr::ToXdr, Address, Bytes, Env};
+use storage::{MIN_TTL, MAX_TTL};
 
 #[contract]
 pub struct CertificateContract;
@@ -19,6 +20,7 @@ pub struct CertificateContract;
 #[contractimpl]
 impl CertificateContract {
     pub fn init(env: Env, admin: Address) -> Result<(), ContractError> {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         if storage::get_admin(&env).is_some() {
             return Err(ContractError::AlreadyInitialized);
         }
@@ -31,6 +33,7 @@ impl CertificateContract {
     }
 
     pub fn toggle_pause(env: Env, caller: Address, paused: bool) -> Result<(), ContractError> {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         storage::require_admin(&env, &caller)?;
         storage::set_paused(&env, paused);
         env.events().publish((symbol_short!("paused"),), paused);
@@ -38,6 +41,7 @@ impl CertificateContract {
     }
 
     pub fn is_paused(env: Env) -> bool {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         storage::is_paused(&env)
     }
 
@@ -48,6 +52,7 @@ impl CertificateContract {
         backend_public_key: Bytes,
         proof: Bytes,
     ) -> Result<(), ContractError> {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         storage::require_not_paused(&env)?;
         wallet.require_auth();
 
@@ -71,11 +76,33 @@ impl CertificateContract {
         Ok(())
     }
 
+    pub fn revoke_certificate(
+        env: Env,
+        caller: Address,
+        wallet: Address,
+        course_id: u64,
+    ) -> Result<(), ContractError> {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::require_admin(&env, &caller)?;
+
+        if !storage::has_certificate(&env, &wallet, course_id) {
+            return Err(ContractError::CertificateNotFound);
+        }
+
+        storage::remove_certificate(&env, &wallet, course_id);
+        env.events()
+            .publish((symbol_short!("cert_rvk"), wallet), course_id);
+
+        Ok(())
+    }
+
     pub fn get_certificate(env: Env, wallet: Address, course_id: u64) -> Option<Certificate> {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         storage::load_certificate(&env, &wallet, course_id)
     }
 
     pub fn has_certificate(env: Env, wallet: Address, course_id: u64) -> bool {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         storage::has_certificate(&env, &wallet, course_id)
     }
 

--- a/contracts/certificates/src/storage.rs
+++ b/contracts/certificates/src/storage.rs
@@ -60,11 +60,17 @@ pub fn load_certificate(env: &Env, wallet: &Address, course_id: u64) -> Option<C
 }
 
 // ~1 year expressed in ledger entries (5-second close time)
-const MIN_TTL: u32 = 3_110_400;
-const MAX_TTL: u32 = 6_220_800;
+pub const MIN_TTL: u32 = 3_110_400;
+pub const MAX_TTL: u32 = 6_220_800;
 
 pub fn save_certificate(env: &Env, wallet: &Address, course_id: u64, certificate: &Certificate) {
     let key = DataKey::Certificate(wallet.clone(), course_id);
     env.storage().persistent().set(&key, certificate);
     env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL);
+}
+
+pub fn remove_certificate(env: &Env, wallet: &Address, course_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Certificate(wallet.clone(), course_id));
 }

--- a/contracts/payout-automation/src/lib.rs
+++ b/contracts/payout-automation/src/lib.rs
@@ -47,6 +47,9 @@ pub struct PayoutAutomation;
 impl PayoutAutomation {
     /// One-time initialisation — sets the admin and first authorised caller.
     pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage()

--- a/contracts/reward/src/lib.rs
+++ b/contracts/reward/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Env, BytesN, Address};
+use soroban_sdk::{contract, contractimpl, Env, BytesN, Address};
 
 mod storage;
 mod signature;
@@ -10,19 +10,9 @@ mod events;
 mod admin;
 mod crypto;
 
-use storage::{set_treasury, set_token, set_reward_amount};
+use storage::{set_treasury, set_token, set_reward_amount, DataKey};
 use admin::require_admin;
 use errors::Error;
-
-#[derive(Clone)]
-#[contracttype]
-pub enum DataKey {
-    Admin,
-    Initialized,
-    BackendPubKey,
-    BackendSigner,
-    UsedNonce(BytesN<32>),
-}
 
 #[contract]
 pub struct RewardContract;

--- a/contracts/reward/src/storage.rs
+++ b/contracts/reward/src/storage.rs
@@ -1,4 +1,14 @@
-use soroban_sdk::{Env, Address, symbol_short};
+use soroban_sdk::{contracttype, Env, Address, BytesN, symbol_short};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Initialized,
+    BackendPubKey,
+    BackendSigner,
+    UsedNonce(BytesN<32>),
+}
 
 const REWARDED: soroban_sdk::Symbol = symbol_short!("REWARDED");
 const TREASURY: soroban_sdk::Symbol = symbol_short!("TREASURY");


### PR DESCRIPTION
## Summary

Fixes four smart-contract issues in a single PR.

### #244 — payout-automation: re-init guard
Added a check at the top of `initialize()` that panics if `DataKey::Admin` already exists in instance storage, preventing the admin from being overwritten by a second call.

### #238 — reward: remove duplicate DataKey definition
Moved the `DataKey` enum into `storage.rs` (where it belongs) and replaced the inline declaration in `lib.rs` with `use storage::DataKey`. The file previously had two conflicting definitions which would not compile.

### #237 — certificates: bump instance storage TTL on every call
Added `env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL)` at the top of every public `#[contractimpl]` function (`init`, `toggle_pause`, `is_paused`, `mint`, `revoke_certificate`, `get_certificate`, `has_certificate`) to prevent contract expiry.

### #235 — certificates: add revoke_certificate admin function
Added `revoke_certificate(env, caller, wallet, course_id)` that:
1. Calls `storage::require_admin` (enforces admin-only access)
2. Returns `CertificateNotFound` if the cert doesn't exist
3. Removes the certificate from persistent storage
4. Emits a `cert_rvk` event with `wallet` and `course_id`

Also added `CertificateNotFound = 8` to `ContractError` and a `remove_certificate` helper in `storage.rs`.

Closes #244
Closes #238
Closes #237
Closes #235