### PR TITLE
fix: enforce admin auth checks in subscription.rs

### DIFF
--- a/contracts/escrow/subscription.rs
+++ b/contracts/escrow/subscription.rs
@@ -33,6 +33,8 @@ pub struct SubscriptionContract;
 
 impl SubscriptionContract {
     fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+        caller.require_auth();
+
         let admin: Address = env
             .storage()
             .instance()
@@ -43,7 +45,6 @@ impl SubscriptionContract {
             return Err(Error::Unauthorized);
         }
 
-        caller.require_auth();
         Ok(())
     }
 
@@ -415,10 +416,7 @@ impl SubscriptionContract {
 
     #[allow(deprecated)]
     pub fn set_usdc_contract(env: Env, admin: Address, usdc_address: Address) -> Result<(), Error> {
-        admin.require_auth();
-
-        // Check if admin is authorized (you might want to implement admin checking logic)
-        // For now, we'll store the USDC contract address
+        Self::require_admin(&env, &admin)?;
         env.storage()
             .instance()
             .set(&SubscriptionDataKey::UsdcContract, &usdc_address);
@@ -631,7 +629,7 @@ impl SubscriptionContract {
 
     /// Creates a new subscription tier. Admin only.
     pub fn create_tier(env: Env, admin: Address, params: CreateTierParams) -> Result<(), Error> {
-        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
 
         // Validate prices
         if params.price < 0 {
@@ -700,7 +698,7 @@ impl SubscriptionContract {
 
     /// Updates an existing subscription tier. Admin only.
     pub fn update_tier(env: Env, admin: Address, params: UpdateTierParams) -> Result<(), Error> {
-        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
 
         let key = SubscriptionDataKey::Tier(params.id.clone());
         let mut tier: SubscriptionTier = env
@@ -796,7 +794,7 @@ impl SubscriptionContract {
 
     /// Deactivates a tier (soft delete). Admin only.
     pub fn deactivate_tier(env: Env, admin: Address, id: String) -> Result<(), Error> {
-        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
 
         let key = SubscriptionDataKey::Tier(id.clone());
         let mut tier: SubscriptionTier = env
@@ -1045,7 +1043,7 @@ impl SubscriptionContract {
 
         // Verify caller is the user or admin
         if caller != change_request.user {
-            // TODO: Add admin check here
+            Self::require_admin(&env, &caller)?;
         }
 
         // Get subscription and update it
@@ -1150,7 +1148,7 @@ impl SubscriptionContract {
         admin: Address,
         params: CreatePromotionParams,
     ) -> Result<(), Error> {
-        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
 
         // Validate tier exists
         let _ = Self::get_tier(env.clone(), params.tier_id.clone())?;


### PR DESCRIPTION
## Summary

Fixes four security vulnerabilities in `contracts/escrow/subscription.rs` where admin authorization was either missing, incomplete, or in the wrong order.

## Changes

- **#270** `require_admin`: Move `caller.require_auth()` to the first line, before the admin address lookup. Previously, the contract revealed whether an address was the admin before verifying their signature.

- **#266** `set_usdc_contract`: Replace `admin.require_auth()` with `Self::require_admin()`. The old code only verified the caller signed the transaction but never checked they were the stored admin, allowing any signer to replace the USDC contract address.

- **#267** `create_tier`, `update_tier`, `deactivate_tier`, `create_promotion`: Replace `admin.require_auth()` with `Self::require_admin()` in all four functions. Same class of vulnerability as #266 — any address could create or modify tiers.

- **#265** `process_tier_change`: Replace the `// TODO: Add admin check here` comment with an actual `Self::require_admin()` call. Without this, any address could process another user's tier change request.

## Closes

Closes #265, 
Closes #266
Closes #267
Closes #270