### PR TITLE
fix: storage, error handling in chv_token and royalty (#273, #274, #275, #276)

### DIFF
--- a/contracts/chv_token/admin.rs
+++ b/contracts/chv_token/admin.rs
@@ -1,7 +1,9 @@
-use soroban_sdk::{Env, Address};
+use soroban_sdk::Env;
 use crate::storage::get_admin;
+use crate::error::TokenError;
 
-pub fn require_admin(env: &Env) {
-    let admin = get_admin(env);
+pub fn require_admin(env: &Env) -> Result<(), TokenError> {
+    let admin = get_admin(env).ok_or(TokenError::NotInitialized)?;
     admin.require_auth();
+    Ok(())
 }

--- a/contracts/chv_token/error.rs
+++ b/contracts/chv_token/error.rs
@@ -1,0 +1,9 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum TokenError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+}

--- a/contracts/chv_token/libs.rs
+++ b/contracts/chv_token/libs.rs
@@ -1,7 +1,10 @@
 use soroban_sdk::{contract, contractimpl, Env, Address};
 
 mod admin;
+mod error;
 mod storage;
+
+use error::TokenError;
 
 #[contract]
 pub struct TokenContract;
@@ -9,22 +12,23 @@ pub struct TokenContract;
 #[contractimpl]
 impl TokenContract {
 
-    pub fn initialize(env: Env, admin: Address) {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), TokenError> {
         if storage::has_admin(&env) {
-            panic!("Already initialized");
+            return Err(TokenError::AlreadyInitialized);
         }
         admin.require_auth();
         storage::set_admin(&env, &admin);
+        Ok(())
     }
 
-    pub fn mint(env: Env, to: Address, amount: i128) {
-        admin::require_admin(&env);
+    pub fn mint(env: Env, to: Address, amount: i128) -> Result<(), TokenError> {
+        admin::require_admin(&env)?;
 
-        // checked arithmetic
         let balance = storage::balance_of(&env, &to);
         let new_balance = balance.checked_add(amount)
             .expect("Overflow");
 
         storage::set_balance(&env, &to, &new_balance);
+        Ok(())
     }
 }

--- a/contracts/chv_token/src/lib.rs
+++ b/contracts/chv_token/src/lib.rs
@@ -4,8 +4,13 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, Address, Env, Symbol, Vec, symbol_short
 };
 
+mod error;
+use error::TokenError;
+
 const DECIMALS: u32 = 7;
 const TOTAL_SUPPLY: i128 = 100_000_000 * 10_i128.pow(DECIMALS);
+const BALANCE_MIN_TTL: u32 = 100_000;
+const BALANCE_MAX_TTL: u32 = 200_000;
 
 #[contracttype]
 pub enum DataKey {
@@ -21,24 +26,26 @@ pub struct CHVToken;
 impl CHVToken {
 
     /// Initialize contract and mint fixed supply to treasury
-    pub fn initialize(env: Env, admin: Address) {
-        // Prevent re-initialization
+    pub fn initialize(env: Env, admin: Address) -> Result<(), TokenError> {
         if env.storage().instance().has(&DataKey::Initialized) {
-            panic!("Already initialized");
+            return Err(TokenError::AlreadyInitialized);
         }
 
         admin.require_auth();
 
-        // Set admin
         env.storage().instance().set(&DataKey::Admin, &admin);
 
-        // Mint entire supply to admin (treasury)
+        // Mint entire supply to admin (treasury) using persistent storage
         env.storage()
-            .instance()
+            .persistent()
             .set(&DataKey::Balance(admin.clone()), &TOTAL_SUPPLY);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Balance(admin.clone()), BALANCE_MIN_TTL, BALANCE_MAX_TTL);
 
-        // Mark as initialized
         env.storage().instance().set(&DataKey::Initialized, &true);
+
+        Ok(())
     }
 
     /// Get total supply
@@ -54,7 +61,7 @@ impl CHVToken {
     /// Get balance of address
     pub fn balance(env: Env, addr: Address) -> i128 {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::Balance(addr))
             .unwrap_or(0)
     }
@@ -75,11 +82,17 @@ impl CHVToken {
         let to_balance = Self::balance(env.clone(), to.clone());
 
         env.storage()
-            .instance()
-            .set(&DataKey::Balance(from), &(from_balance - amount));
+            .persistent()
+            .set(&DataKey::Balance(from.clone()), &(from_balance - amount));
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Balance(from), BALANCE_MIN_TTL, BALANCE_MAX_TTL);
 
         env.storage()
-            .instance()
-            .set(&DataKey::Balance(to), &(to_balance + amount));
+            .persistent()
+            .set(&DataKey::Balance(to.clone()), &(to_balance + amount));
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Balance(to), BALANCE_MIN_TTL, BALANCE_MAX_TTL);
     }
 }

--- a/contracts/chv_token/storage.rs
+++ b/contracts/chv_token/storage.rs
@@ -6,9 +6,6 @@ pub fn set_admin(env: &Env, admin: &Address) {
     env.storage().instance().set(&ADMIN_KEY, admin);
 }
 
-pub fn get_admin(env: &Env) -> Address {
-    env.storage()
-        .instance()
-        .get(&ADMIN_KEY)
-        .expect("Admin not set")
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&ADMIN_KEY)
 }

--- a/contracts/escrow/royalty.rs
+++ b/contracts/escrow/royalty.rs
@@ -48,9 +48,16 @@ impl RoyaltyModule {
             (recipients.len(), env.ledger().timestamp()),
         );
 
+        const MIN_TTL: u32 = 100_000;
+        const MAX_TTL: u32 = 200_000;
+
         env.storage()
             .persistent()
-            .set(&DataKey::Royalty(token_id), &config);
+            .set(&DataKey::Royalty(token_id.clone()), &config);
+
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Royalty(token_id), MIN_TTL, MAX_TTL);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Fixes four issues in `chv_token` and `escrow/royalty`:

### #273 — royalty.rs: missing `extend_ttl` after persistent set
Added `extend_ttl` call after `persistent().set` in `set_royalty` so royalty configs are not evicted from the ledger.

### #274 — chv_token: balances in instance storage
Moved all `DataKey::Balance` reads/writes from `instance()` to `persistent()` storage with TTL extension on every write, preventing the instance storage size cap from being hit.

### #275 — chv_token: initialize uses `panic!`
Defined `TokenError` enum (with `#[contracterror]`) in `error.rs`. Changed `initialize` to return `Result<(), TokenError>` and replaced `panic!("Already initialized")` with `Err(TokenError::AlreadyInitialized)`.

### #276 — chv_token/admin.rs: `get_admin` uses `.expect()`
Changed `get_admin` in `storage.rs` to return `Option<Address>`. Updated `require_admin` in `admin.rs` to return `Result<(), TokenError>` and use `.ok_or(TokenError::NotInitialized)?` instead of panicking.

Closes #273
Closes #274
Closes #275
Closes #276