### PR TITLE
fix: resolve issues #239, #240, #241, #257 in reward contract

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -6,7 +6,9 @@ members = [
     "chainverse-core",
     "course_registry",
     "escrow",
+    "escrow-vault",
     "payout-automation",
+    "reward",
     "shared"
 ]
 

--- a/contracts/reward/src/errors.rs
+++ b/contracts/reward/src/errors.rs
@@ -7,4 +7,5 @@ pub enum Error {
     InvalidSignature   = 2,
     AlreadyInitialized = 3,
     AlreadyRewarded    = 4,
+    NotInitialized     = 5,
 }

--- a/contracts/reward/src/lib.rs
+++ b/contracts/reward/src/lib.rs
@@ -41,12 +41,6 @@ impl RewardContract {
         Ok(())
     }
 
-    pub fn set_backend_pubkey(env: Env, pubkey: BytesN<32>) -> Result<(), Error> {
-        require_admin(&env)?;
-        env.storage().instance().set(&DataKey::BackendPubKey, &pubkey);
-        Ok(())
-    }
-
     pub fn rotate_backend_pubkey(env: Env, new_pubkey: BytesN<32>) -> Result<(), Error> {
         require_admin(&env)?;
         env.storage().instance().set(&DataKey::BackendPubKey, &new_pubkey);

--- a/contracts/reward/src/reward.rs
+++ b/contracts/reward/src/reward.rs
@@ -10,9 +10,9 @@ pub fn claim_reward(env: Env, user: Address) -> Result<(), Error> {
         return Err(Error::AlreadyRewarded);
     }
 
-    let treasury = get_treasury(&env);
-    let token_address = get_token(&env);
-    let reward_amount = get_reward_amount(&env);
+    let treasury = get_treasury(&env)?;
+    let token_address = get_token(&env)?;
+    let reward_amount = get_reward_amount(&env)?;
 
     let token_client = Client::new(&env, &token_address);
     token_client.transfer(&treasury, &user, &reward_amount);

--- a/contracts/reward/src/storage.rs
+++ b/contracts/reward/src/storage.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{contracttype, Env, Address, BytesN, symbol_short};
+use crate::errors::Error;
 
 #[derive(Clone)]
 #[contracttype]
@@ -27,22 +28,22 @@ pub fn set_treasury(env: &Env, treasury: &Address) {
     env.storage().instance().set(&TREASURY, treasury);
 }
 
-pub fn get_treasury(env: &Env) -> Address {
-    env.storage().instance().get(&TREASURY).unwrap()
+pub fn get_treasury(env: &Env) -> Result<Address, Error> {
+    env.storage().instance().get(&TREASURY).ok_or(Error::NotInitialized)
 }
 
 pub fn set_token(env: &Env, token: &Address) {
     env.storage().instance().set(&TOKEN, token);
 }
 
-pub fn get_token(env: &Env) -> Address {
-    env.storage().instance().get(&TOKEN).unwrap()
+pub fn get_token(env: &Env) -> Result<Address, Error> {
+    env.storage().instance().get(&TOKEN).ok_or(Error::NotInitialized)
 }
 
 pub fn set_reward_amount(env: &Env, amount: i128) {
     env.storage().instance().set(&REWARD_AMOUNT, &amount);
 }
 
-pub fn get_reward_amount(env: &Env) -> i128 {
-    env.storage().instance().get(&REWARD_AMOUNT).unwrap()
+pub fn get_reward_amount(env: &Env) -> Result<i128, Error> {
+    env.storage().instance().get(&REWARD_AMOUNT).ok_or(Error::NotInitialized)
 }


### PR DESCRIPTION
## Summary

Fixes four issues in the `reward` contract and workspace configuration.

### Changes

**#239 — Duplicate `DataKey` import**
The import was already clean in the current codebase (no action needed beyond verification).

**#240 — Remove `set_backend_pubkey`**
Removed `set_backend_pubkey` which was identical to `rotate_backend_pubkey`. Kept `rotate_backend_pubkey` as the canonical function.

**#241 — Replace `unwrap()` with proper error handling**
- Added `NotInitialized = 5` variant to `Error` enum in `errors.rs`
- Changed `get_treasury`, `get_token`, `get_reward_amount` in `storage.rs` to return `Result<T, Error>`
- Replaced `.unwrap()` with `.ok_or(Error::NotInitialized)`
- Updated `reward.rs` call sites to propagate errors with `?`

**#257 — Add missing workspace members**
Added `escrow-vault` and `reward` to the `members` array in `contracts/Cargo.toml`.

Closes #239
Closes #240
Closes #241
Closes #257