### PR TITLE
fix: resolve issues #268, #269, #271, #272 in escrow contracts

### DIFF
--- a/contracts/escrow/royalty.rs
+++ b/contracts/escrow/royalty.rs
@@ -4,7 +4,7 @@
 use crate::errors::Error;
 use crate::membership_token::DataKey;
 use crate::types::{RoyaltyConfig, RoyaltyInfo, RoyaltyRecipient};
-use soroban_sdk::{symbol_short, Address, BytesN, Env, Vec};
+use soroban_sdk::{symbol_short, token, Address, BytesN, Env, Vec};
 
 pub struct RoyaltyModule;
 
@@ -30,9 +30,21 @@ impl RoyaltyModule {
     /// Sets or updates the royalty configuration for a token
     pub fn set_royalty(
         env: Env,
+        admin: Address,
         token_id: BytesN<32>,
         recipients: Vec<RoyaltyRecipient>,
     ) -> Result<(), Error> {
+        // Require admin authorization
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        stored_admin.require_auth();
+        if stored_admin != admin {
+            return Err(Error::Unauthorized);
+        }
+
         // Validation
         let _ = Self::validate_config(&recipients)?;
 
@@ -62,12 +74,13 @@ impl RoyaltyModule {
         Ok(())
     }
 
-    /// Calculates required royalty payments based on sale price and emits distribution events.
+    /// Calculates and transfers royalty payments for each recipient.
     pub fn calculate_and_pay_royalties(
         env: &Env,
         token_id: &BytesN<32>,
         payment_token: &Address,
         sale_price: i128,
+        payer: &Address,
     ) -> Result<i128, Error> {
         if sale_price <= 0 {
             return Ok(0);
@@ -83,19 +96,19 @@ impl RoyaltyModule {
                 return Ok(0);
             }
 
+            let token_client = token::Client::new(env, payment_token);
             let mut total_royalty_amount: i128 = 0;
 
             for recipient in cfg.recipients.iter() {
-                // Calculate portion using basis points (percentage * sale_price / 10000)
                 let amount =
                     (sale_price * recipient.percentage as i128) / Self::MAX_ROYALTY_BPS as i128;
 
                 if amount > 0 {
                     total_royalty_amount += amount;
 
-                    // Note: Here we'd normally call `token::Client::new(env, payment_token).transfer(...)`
-                    // To keep things simple and avoiding external cross-contract token integrations for the royalty distribution,
-                    // we emit an event that off-chain indexers or wrapper contracts can use to fulfill the payment synchronously or asynchronously.
+                    // Transfer royalty to recipient
+                    token_client.transfer(payer, &recipient.address, &amount);
+
                     env.events().publish(
                         (
                             symbol_short!("roy_paid"),

--- a/contracts/escrow/staking.rs
+++ b/contracts/escrow/staking.rs
@@ -99,6 +99,11 @@ impl StakingModule {
         env.storage()
             .persistent()
             .set(&StakingDataKey::Tier(tier.id.clone()), &tier);
+        env.storage().persistent().extend_ttl(
+            &StakingDataKey::Tier(tier.id.clone()),
+            STAKE_TTL_LEDGERS,
+            STAKE_TTL_LEDGERS,
+        );
 
         // Append tier ID to the tier list.
         let mut list: Vec<String> = env

--- a/contracts/escrow/subscription.rs
+++ b/contracts/escrow/subscription.rs
@@ -452,6 +452,30 @@ impl SubscriptionContract {
         // Capture old status for event emission
         let old_status = subscription.status.clone();
 
+        // Calculate and transfer prorated refund for remaining subscription time
+        let current_time = env.ledger().timestamp();
+        if subscription.status == MembershipStatus::Active
+            && subscription.expires_at > current_time
+            && subscription.amount > 0
+        {
+            let remaining = subscription.expires_at - current_time;
+            let total_duration: u64 = match subscription.billing_cycle {
+                BillingCycle::Monthly => 30 * 24 * 60 * 60,
+                BillingCycle::Annual => 365 * 24 * 60 * 60,
+            };
+            let refund_amount =
+                (subscription.amount * remaining as i128) / total_duration as i128;
+            if refund_amount > 0 {
+                let token_client =
+                    token::Client::new(&env, &subscription.payment_token);
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &subscription.user,
+                    &refund_amount,
+                );
+            }
+        }
+
         // Update status to inactive
         subscription.status = MembershipStatus::Inactive;
         subscription.paused_at = None;

--- a/contracts/escrow/test.rs
+++ b/contracts/escrow/test.rs
@@ -3237,7 +3237,7 @@ fn test_royalty_config() {
         },
     ];
 
-    client.set_royalty(&token_id, &recipients);
+    client.set_royalty(&admin, &token_id, &recipients);
 
     let info = client.get_royalty_info(&token_id).unwrap();
     assert_eq!(info.config.recipients.len(), 2);
@@ -3269,7 +3269,7 @@ fn test_royalty_validation_fail() {
         },
     ];
 
-    client.set_royalty(&token_id, &recipients);
+    client.set_royalty(&admin, &token_id, &recipients);
 }
 
 #[test]
@@ -3295,7 +3295,7 @@ fn test_transfer_with_royalty_events() {
             percentage: 1000, // 10%
         },
     ];
-    client.set_royalty(&token_id, &recipients);
+    client.set_royalty(&admin, &token_id, &recipients);
 
     // Verify it was set
     let info = client.get_royalty_info(&token_id).unwrap();


### PR DESCRIPTION
## Summary

Fixes four bugs in the escrow contract modules.

### #268 — cancel_subscription: missing prorated refund
`cancel_subscription` now calculates the remaining subscription time, computes a prorated refund amount, and transfers tokens back to the user via `TokenClient::transfer` before marking the subscription inactive.

### #269 — create_staking_tier: missing TTL extension
`create_staking_tier` now calls `extend_ttl` on the newly saved tier record using `STAKE_TTL_LEDGERS`, preventing tier data from expiring off the ledger.

### #271 — set_royalty: no admin auth check
`set_royalty` now retrieves the stored admin from instance storage and calls `require_auth()` before allowing any royalty configuration changes, preventing unauthorized overwrites.

### #272 — calculate_and_pay_royalties: event-only, no actual transfers
`calculate_and_pay_royalties` now performs actual on-chain token transfers to each recipient via `TokenClient::transfer`. A `payer` parameter is added. Events are still emitted alongside transfers for indexer tracking.

Closes #268
Closes #269
Closes #271
Closes #272