### PR TITLE
fix: resolve issues #277, #278, #279, #281

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contracts/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('contracts/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build all contracts
+        working-directory: contracts
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Run tests
+        working-directory: contracts
+        run: cargo test --features testutils

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
     "certificates",
     "chainverse-core",
+    "common",
     "course_registry",
     "escrow",
     "escrow-vault",

--- a/contracts/chainverse-core/src/escrow/mod.rs
+++ b/contracts/chainverse-core/src/escrow/mod.rs
@@ -118,6 +118,9 @@ pub fn release(env: &Env, caller: Address, id: u64) -> Result<(), ContractError>
         return Err(ContractError::Unauthorized);
     }
 
+    soroban_sdk::token::Client::new(env, &record.token)
+        .transfer(&env.current_contract_address(), &record.recipient, &record.amount);
+
     record.status = EscrowStatus::Completed;
     save(env, &record);
     Ok(())

--- a/contracts/common/Cargo.toml
+++ b/contracts/common/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "common"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "common"
+path = "lib.rs"
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -10,3 +10,8 @@ pub use storage::{
     get_instance_storage, get_persistent_storage, remove_instance_storage,
     remove_persistent_storage, set_instance_storage, set_persistent_storage,
 };
+
+/// Minimum TTL (in ledgers) for persistent storage entries (~1 day at 5s/ledger).
+pub const MIN_TTL: u32 = 17_280;
+/// Maximum TTL (in ledgers) for persistent storage entries (~30 days at 5s/ledger).
+pub const MAX_TTL: u32 = 518_400;

--- a/contracts/shared/src/storage.rs
+++ b/contracts/shared/src/storage.rs
@@ -60,6 +60,9 @@ where
     V: IntoVal<Env, Val>,
 {
     env.storage().persistent().set(key, val);
+    env.storage()
+        .persistent()
+        .extend_ttl(key, crate::MIN_TTL, crate::MAX_TTL);
 }
 
 /// Removes a key and its associated value from persistent storage.


### PR DESCRIPTION
## Summary

Fixes four open issues in a single PR.

---

### Closes #277 — chv_token transfer function
The `transfer` function was already implemented in `chv_token/src/lib.rs` with proper auth, balance validation, and TTL extension on both sender and recipient balances. No code change needed; this PR closes the issue.

---

### Closes #278 — common/vesting not in workspace
- Created `contracts/common/Cargo.toml` declaring the `common` crate with `cdylib`/`rlib` targets.
- Added `"common"` to the `members` list in `contracts/Cargo.toml` so `AcademyVestingContract` is compiled as part of the workspace.

---

### Closes #279 — shared storage missing extend_ttl
- Added `MIN_TTL = 17_280` and `MAX_TTL = 518_400` (ledger counts ≈ 1 day and 30 days at 5 s/ledger) as public constants in `shared/src/lib.rs`.
- Updated `set_persistent_storage` in `shared/src/storage.rs` to call `extend_ttl` after every `persistent().set`, preventing shared records from expiring unexpectedly.

---

### Closes #281 — escrow release never transfers tokens (critical)
- Added `soroban_sdk::token::Client::new(env, &record.token).transfer(...)` in `release()` before marking the escrow `Completed`.
- Funds are now transferred to the recipient instead of being permanently locked in the contract.

---

### CI workflow
- Added `.github/workflows/ci.yml` to build all contracts targeting `wasm32-unknown-unknown` and run tests on every push/PR to `main`.