### PR TITLE
fix: resolve issues #303, #304, #305, #306 in staking and royalty contracts

### DIFF
--- a/contracts/escrow/staking.rs
+++ b/contracts/escrow/staking.rs
@@ -20,6 +20,8 @@ pub enum StakingDataKey {
     Tier(String),
     /// Active stake per staker address (persistent storage).
     Stake(Address),
+    /// Running total of all active staked tokens (instance storage).
+    TotalStaked,
 }
 
 // ---------------------------------------------------------------------------
@@ -56,7 +58,10 @@ impl StakingModule {
             return Err(Error::Unauthorized);
         }
 
-        if config.emergency_unstake_penalty_bps > 10_000 {
+        const MIN_PENALTY_BPS: u32 = 100; // 1% minimum penalty
+        if config.emergency_unstake_penalty_bps < MIN_PENALTY_BPS
+            || config.emergency_unstake_penalty_bps > 10_000
+        {
             return Err(Error::InvalidPaymentAmount);
         }
 
@@ -122,6 +127,53 @@ impl StakingModule {
                 tier.id.clone(),
             ),
             env.ledger().timestamp(),
+        );
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin – penalty withdrawal
+    // -----------------------------------------------------------------------
+
+    /// Withdraw accumulated penalty funds to a recipient address. Admin only.
+    ///
+    /// Penalty balance = contract token balance − total active stakes.
+    pub fn withdraw_penalties(
+        env: Env,
+        admin: Address,
+        recipient: Address,
+    ) -> Result<(), Error> {
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&MembershipDataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        stored_admin.require_auth();
+        if stored_admin != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let config = Self::get_config(&env)?;
+        let token_client = token::Client::new(&env, &config.staking_token);
+
+        let contract_balance = token_client.balance(&env.current_contract_address());
+        let total_staked: i128 = env
+            .storage()
+            .instance()
+            .get(&StakingDataKey::TotalStaked)
+            .unwrap_or(0);
+
+        let penalty_balance = contract_balance.saturating_sub(total_staked);
+        if penalty_balance <= 0 {
+            return Ok(());
+        }
+
+        token_client.transfer(&env.current_contract_address(), &recipient, &penalty_balance);
+
+        env.events().publish(
+            (String::from_str(&env, "PenaltiesWithdrawn"), admin),
+            (recipient, penalty_balance),
         );
 
         Ok(())
@@ -197,6 +249,7 @@ impl StakingModule {
             };
 
             Self::save_stake(&env, &staker, &updated);
+            Self::adjust_total_staked(&env, amount);
 
             env.events().publish(
                 (String::from_str(&env, "Staked"), staker.clone(), tier_id),
@@ -226,6 +279,7 @@ impl StakingModule {
         };
 
         Self::save_stake(&env, &staker, &stake);
+        Self::adjust_total_staked(&env, amount);
 
         env.events().publish(
             (String::from_str(&env, "Staked"), staker.clone(), tier_id),
@@ -273,6 +327,7 @@ impl StakingModule {
         env.storage()
             .persistent()
             .remove(&StakingDataKey::Stake(staker.clone()));
+        Self::adjust_total_staked(&env, -stake.amount);
 
         env.events().publish(
             (String::from_str(&env, "Unstaked"), staker.clone()),
@@ -324,6 +379,7 @@ impl StakingModule {
         env.storage()
             .persistent()
             .remove(&StakingDataKey::Stake(staker.clone()));
+        Self::adjust_total_staked(&env, -stake.amount);
 
         env.events().publish(
             (String::from_str(&env, "EmergencyUnstaked"), staker.clone()),
@@ -397,5 +453,16 @@ impl StakingModule {
             STAKE_TTL_LEDGERS,
             STAKE_TTL_LEDGERS,
         );
+    }
+
+    fn adjust_total_staked(env: &Env, delta: i128) {
+        let current: i128 = env
+            .storage()
+            .instance()
+            .get(&StakingDataKey::TotalStaked)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&StakingDataKey::TotalStaked, &current.saturating_add(delta));
     }
 }


### PR DESCRIPTION
Closes #303
Closes #304
Closes #305
Closes #306

## Summary

### #303 — staking.rs: enforce minimum penalty floor
Added `MIN_PENALTY_BPS = 100` (1%) and updated `set_staking_config` to reject `emergency_unstake_penalty_bps` below this floor. Previously 0 was accepted, making emergency unstake identical to normal unstake.

### #304 — royalty.rs: on-chain transfers already present (no change)
Verified `calculate_and_pay_royalties` already calls `token::Client::transfer` for each recipient on-chain alongside the events.

### #305 — staking.rs: add withdraw_penalties admin function
- Added `TotalStaked` to `StakingDataKey` and `adjust_total_staked` helper (called on every stake/unstake).
- Added `withdraw_penalties(env, admin, recipient)` that transfers `contract_balance − total_staked` to the recipient.

### #306 — subscription.rs: auth order already correct (no change)
`require_admin` already calls `caller.require_auth()` as its first statement before any storage lookup.

## Files changed
- `contracts/escrow/staking.rs`