### PR TITLE
build: implement optimize release profile in Cargo.toml for smallest WASM output

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -15,3 +15,12 @@ members = [
 
 [workspace.dependencies]
 soroban-sdk = "22.0.0"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+lto = true
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
Closes #335 

### Summary

Soroban charges upload fees proportional to WASM binary size. Without explicit release profile tuning, `cargo build --release` applies Rust's defaults — which prioritize build speed over binary size and leave considerable dead weight in the output `.wasm`. This PR adds a `[profile.release]` block to the workspace `Cargo.toml` that targets the smallest possible WASM output while preserving correctness guarantees.

---

### Change

**`Cargo.toml`**

```toml
[profile.release]
opt-level = "z"       # Optimize for size (smaller than "s", trades some speed)
overflow-checks = true # Keep integer overflow checks; required for Soroban correctness
debug = 0              # No debug info in the binary
strip = "symbols"     # Strip symbol table from output WASM
lto = true             # Link-time optimisation across all crates; removes dead code
codegen-units = 1      # Single codegen unit enables maximum LTO effectiveness
panic = "abort"       # No unwinding machinery; significantly reduces binary size
```

---

### Why each flag matters for WASM size

| Flag | Effect |
|---|---|
| `opt-level = "z"` | Instructs LLVM to prioritise size over speed at every inlining and loop decision |
| `lto = true` | Enables whole-program dead-code elimination across crate boundaries |
| `codegen-units = 1` | Required for LTO to see the full program; splitting units limits its reach |
| `panic = "abort"` | Removes the entire stack-unwinding runtime (~tens of KB in WASM) |
| `strip = "symbols"` | Drops the symbol table, which is not needed on-chain |
| `debug = 0` | Ensures no DWARF sections are embedded |
| `overflow-checks = true` | Kept deliberately — Soroban contracts must trap on integer overflow, not silently wrap |

Together these flags are consistent with the [Soroban documentation's recommended build settings](https://developers.stellar.org/docs/build/smart-contracts/getting-started/deploy-to-testnet) and are standard across the Stellar smart contract ecosystem.

---

### Impact

- Reduces deployed WASM size, directly lowering upload (deployment) fees on Soroban
- No change to contract logic, ABI, or test behaviour — `overflow-checks` remains on so arithmetic traps are preserved
- Applies workspace-wide; all crates under `[workspace]` inherit this profile automatically

---

### Testing

Build all contracts with the optimised profile and compare binary sizes:

```bash
# Before (default)
cargo build --release --target wasm32-unknown-unknown
ls -lh target/wasm32-unknown-unknown/release/*.wasm

# After (this PR — same command, profile now applied)
cargo build --release --target wasm32-unknown-unknown
ls -lh target/wasm32-unknown-unknown/release/*.wasm
```

All existing tests continue to pass:

```bash
cargo test
```

---

### Checklist

- [x] `[profile.release]` block added to workspace `Cargo.toml`
- [x] All seven flags from the issue spec included
- [x] `overflow-checks = true` preserved for Soroban correctness
- [x] No contract logic changed
- [x] Existing tests unaffected