### PR TITLE
fix(mogbonjubolaolasunkanmi-art): Makefile targets, escrow-vault token transfers, refund_expired

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -1,8 +1,17 @@
+CARGO = cargo
+TARGET = wasm32-unknown-unknown
+
 build:
-	cargo build --target wasm32-unknown-unknown --release
+	$(CARGO) build --workspace --release --target $(TARGET)
 
 test:
-	cargo test
+	$(CARGO) test --workspace
 
 fmt:
-	cargo fmt --all
+	$(CARGO) fmt --all
+
+check:
+	$(CARGO) clippy --workspace -- -D warnings
+
+clean:
+	$(CARGO) clean

--- a/contracts/chainverse-core/src/escrow/mod.rs
+++ b/contracts/chainverse-core/src/escrow/mod.rs
@@ -239,6 +239,12 @@ pub fn refund_expired(env: &Env, id: u64) -> Result<(), ContractError> {
         return Err(ContractError::InvalidEscrowState);
     }
 
+    TokenClient::new(env, &record.token).transfer(
+        &env.current_contract_address(),
+        &record.depositor,
+        &record.amount,
+    );
+
     record.status = EscrowStatus::Expired;
     save(env, &record);
     Ok(())


### PR DESCRIPTION
Fixes assigned to @mogbonjubolaolasunkanmi-art.

- Closes #334: Add `check` (clippy) and `clean` targets to `contracts/Makefile`
- Closes #356: `refund_expired` now transfers tokens back to depositor before marking Expired
- Closes #357: `create_vault` pulls tokens from depositor into contract on creation
- Closes #358: `approve_release` transfers tokens to recipient when all approvers sign off
