### PR TITLE
fix(Userhorlie): certificates backend key security, subscription admin checks, escrow persistent storage

### DIFF
--- a/contracts/certificates/src/lib.rs
+++ b/contracts/certificates/src/lib.rs
@@ -19,7 +19,7 @@ pub struct CertificateContract;
 
 #[contractimpl]
 impl CertificateContract {
-    pub fn init(env: Env, admin: Address) -> Result<(), ContractError> {
+    pub fn init(env: Env, admin: Address, backend_public_key: Bytes) -> Result<(), ContractError> {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         if storage::get_admin(&env).is_some() {
             return Err(ContractError::AlreadyInitialized);
@@ -28,6 +28,7 @@ impl CertificateContract {
         // The deployer must sign to prove they control the intended admin address.
         admin.require_auth();
         storage::set_admin(&env, &admin);
+        storage::set_backend_pubkey(&env, &backend_public_key);
         storage::set_paused(&env, false);
         Ok(())
     }
@@ -49,7 +50,6 @@ impl CertificateContract {
         env: Env,
         wallet: Address,
         course_id: u64,
-        backend_public_key: Bytes,
         proof: Bytes,
     ) -> Result<(), ContractError> {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
@@ -59,6 +59,9 @@ impl CertificateContract {
         if storage::has_certificate(&env, &wallet, course_id) {
             return Err(ContractError::CertificateExists);
         }
+
+        let backend_public_key = storage::get_backend_pubkey(&env)
+            .ok_or(ContractError::NotInitialized)?;
 
         let payload = (wallet.clone(), course_id).to_xdr(&env);
         verify::verify_backend_proof(&env, &backend_public_key, &payload, &proof)?;

--- a/contracts/certificates/src/storage.rs
+++ b/contracts/certificates/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contracttype, Address, Bytes, Env};
 
 use crate::{Certificate, ContractError};
 
@@ -8,6 +8,7 @@ pub enum DataKey {
     Admin,
     Paused,
     Certificate(Address, u64),
+    BackendPubKey,
 }
 
 pub fn get_admin(env: &Env) -> Option<Address> {
@@ -73,4 +74,12 @@ pub fn remove_certificate(env: &Env, wallet: &Address, course_id: u64) {
     env.storage()
         .persistent()
         .remove(&DataKey::Certificate(wallet.clone(), course_id));
+}
+
+pub fn set_backend_pubkey(env: &Env, pubkey: &Bytes) {
+    env.storage().instance().set(&DataKey::BackendPubKey, pubkey);
+}
+
+pub fn get_backend_pubkey(env: &Env) -> Option<Bytes> {
+    env.storage().instance().get(&DataKey::BackendPubKey)
 }

--- a/contracts/certificates/src/test.rs
+++ b/contracts/certificates/src/test.rs
@@ -34,11 +34,10 @@ fn test_transfer_fails() {
     let user2 = Address::generate(&env);
     let signer = signing_key();
 
-    client.init(&admin);
+    client.init(&admin, &public_key_bytes(&env, &signer));
     client.mint(
         &user1,
         &1,
-        &public_key_bytes(&env, &signer),
         &proof_bytes(&env, &signer, &user1, 1),
     );
 
@@ -58,18 +57,16 @@ fn duplicate_mint_fails() {
     let wallet = Address::generate(&env);
     let signer = signing_key();
 
-    client.init(&admin);
+    client.init(&admin, &public_key_bytes(&env, &signer));
     client.mint(
         &wallet,
         &7,
-        &public_key_bytes(&env, &signer),
         &proof_bytes(&env, &signer, &wallet, 7),
     );
 
     let second_attempt = client.try_mint(
         &wallet,
         &7,
-        &public_key_bytes(&env, &signer),
         &proof_bytes(&env, &signer, &wallet, 7),
     );
 


### PR DESCRIPTION
Fixes assigned to @Userhorlie.

- Closes #363: `backend_public_key` stored in `init`, read from storage in `mint` — callers can no longer supply their own key to forge certificates
- Closes #364: `process_tier_change` enforces admin check when `caller != change_request.user`
- Closes #365: `set_usdc_contract` verifies caller is stored admin via `require_admin`
- Closes #366: escrow records use `persistent()` storage keyed by escrow ID
