### PR TITLE
fix: resolve storage issues #373, #375, #377 and add testnet script #378

### DIFF
--- a/scripts/setup-testnet-account.sh
+++ b/scripts/setup-testnet-account.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Generate a new keypair
+stellar keys generate deployer --network testnet
+PUBKEY=$(stellar keys address deployer)
+echo "Deployer public key: $PUBKEY"
+# Fund via Friendbot
+curl -s "https://friendbot.stellar.org?addr=$PUBKEY" | jq .
+echo "Account funded on testnet"


### PR DESCRIPTION
## Summary

Resolves all four assigned storage and tooling issues.

### Issue #373 — staking.rs: extend_ttl for staking tier records
Already implemented: `create_staking_tier` saves tiers to `persistent()` storage and calls `extend_ttl` immediately after each write.

### Issue #375 — escrow-vault/lib.rs: vault records in persistent storage
Already implemented: `create_vault`, `approve_release`, and `cancel_vault` all use `env.storage().persistent()` for vault records. Only `NextId` (a counter) uses `instance()`, which is correct.

### Issue #377 — chv_token/src/lib.rs: token balances in persistent storage
Already implemented: all `DataKey::Balance(Address)` reads and writes use `env.storage().persistent()` with `extend_ttl` on every write.

### Issue #378 — Create scripts/setup-testnet-account.sh
Added `scripts/setup-testnet-account.sh` that generates a deployer keypair and funds it via Stellar Friendbot.

## Changes
- `scripts/setup-testnet-account.sh` (new file)

Closes #373
Closes #375
Closes #377
Closes #378