### PR TITLE
ci: install stellar cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,26 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-
-      - name: Security audit
-        working-directory: contracts
-        run: cargo audit
-
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
           path: |
+            ~/.cargo/bin
             ~/.cargo/registry
             ~/.cargo/git
             contracts/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('contracts/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli --features opt
+
+      - name: Security audit
+        working-directory: contracts
+        run: cargo audit
 
       - name: Build all contracts
         working-directory: contracts


### PR DESCRIPTION
Summary:
- Install Stellar CLI in CI so workflows can run `stellar contract` commands.
- Cache `~/.cargo/bin` to avoid reinstalling on every run.

Validation:
- Not run locally (GitHub Actions).

Closes #386
Closes #387
Closes #388