### PR TITLE
test(staking): add unit tests for stake_tokens and emergency_unstake

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -10,7 +10,8 @@ members = [
     "escrow-vault",
     "payout-automation",
     "shared",
-    "chv_token"
+    "chv_token",
+    "staking"
 ]
 
 [workspace.dependencies]

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "staking"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -1,0 +1,355 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, token, Address, Env, String,
+};
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Config,
+    Tier(String),
+    Stake(Address),
+    TotalStaked,
+}
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub struct StakingConfig {
+    pub staking_enabled: bool,
+    /// Emergency-unstake penalty in basis points (100–10 000).
+    pub emergency_unstake_penalty_bps: u32,
+    /// Token used for staking.
+    pub staking_token: Address,
+    /// Separate pool token used for rewards (unused in unit tests but required
+    /// for full contract compatibility).
+    pub reward_pool: Address,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct StakingTier {
+    pub id: String,
+    pub name: String,
+    /// Minimum amount required to stake into this tier.
+    pub min_stake_amount: i128,
+    /// Seconds the stake is locked before a normal unstake is allowed.
+    pub lock_duration: u64,
+    pub reward_multiplier_bps: u32,
+    pub base_rate_bps: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct StakeInfo {
+    pub staker: Address,
+    pub amount: i128,
+    pub tier_id: String,
+    pub staked_at: u64,
+    pub unlock_at: u64,
+    pub claimed_rewards: i128,
+    pub emergency_unstaked: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    AdminNotSet = 1,
+    Unauthorized = 2,
+    /// Penalty bps was 0 or out of the 100–10 000 range.
+    InvalidPenaltyBps = 3,
+    StakingNotConfigured = 4,
+    StakingDisabled = 5,
+    TierNotFound = 6,
+    BelowMinimumStake = 7,
+    StakeNotFound = 8,
+    StillLocked = 9,
+    Overflow = 10,
+}
+
+// ---------------------------------------------------------------------------
+// TTL constant
+// ---------------------------------------------------------------------------
+
+const STAKE_TTL_LEDGERS: u32 = 518_400; // ~30 days
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct StakingContract;
+
+#[contractimpl]
+impl StakingContract {
+    // -----------------------------------------------------------------------
+    // Bootstrap
+    // -----------------------------------------------------------------------
+
+    /// Store the contract admin (call once after deployment).
+    pub fn set_admin(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin – configuration
+    // -----------------------------------------------------------------------
+
+    /// Set the global staking configuration.
+    ///
+    /// `emergency_unstake_penalty_bps` must be in the range 100–10 000
+    /// (i.e. 1 %–100 %); zero is rejected so that emergency-unstake always
+    /// carries a meaningful disincentive.
+    pub fn set_staking_config(
+        env: Env,
+        admin: Address,
+        config: StakingConfig,
+    ) -> Result<(), Error> {
+        Self::assert_admin(&env, &admin)?;
+
+        const MIN_PENALTY_BPS: u32 = 100;
+        if config.emergency_unstake_penalty_bps < MIN_PENALTY_BPS
+            || config.emergency_unstake_penalty_bps > 10_000
+        {
+            return Err(Error::InvalidPenaltyBps);
+        }
+
+        env.storage().instance().set(&DataKey::Config, &config);
+        Ok(())
+    }
+
+    /// Create a new staking tier.
+    pub fn create_staking_tier(env: Env, admin: Address, tier: StakingTier) -> Result<(), Error> {
+        Self::assert_admin(&env, &admin)?;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Tier(tier.id.clone()), &tier);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Tier(tier.id.clone()),
+            STAKE_TTL_LEDGERS,
+            STAKE_TTL_LEDGERS,
+        );
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin – penalty withdrawal
+    // -----------------------------------------------------------------------
+
+    /// Transfer accumulated penalty funds (contract balance minus active
+    /// stakes) to `recipient`.
+    pub fn withdraw_penalties(env: Env, admin: Address, recipient: Address) -> Result<(), Error> {
+        Self::assert_admin(&env, &admin)?;
+
+        let config = Self::load_config(&env)?;
+        let token_client = token::Client::new(&env, &config.staking_token);
+
+        let contract_balance = token_client.balance(&env.current_contract_address());
+        let total_staked: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalStaked)
+            .unwrap_or(0);
+
+        let penalty_balance = contract_balance.saturating_sub(total_staked);
+        if penalty_balance > 0 {
+            token_client.transfer(
+                &env.current_contract_address(),
+                &recipient,
+                &penalty_balance,
+            );
+        }
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // User – stake / unstake
+    // -----------------------------------------------------------------------
+
+    /// Lock `amount` tokens in the given tier.
+    pub fn stake_tokens(
+        env: Env,
+        staker: Address,
+        tier_id: String,
+        amount: i128,
+    ) -> Result<(), Error> {
+        staker.require_auth();
+
+        let config = Self::load_config(&env)?;
+        if !config.staking_enabled {
+            return Err(Error::StakingDisabled);
+        }
+
+        let tier: StakingTier = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Tier(tier_id.clone()))
+            .ok_or(Error::TierNotFound)?;
+
+        if amount < tier.min_stake_amount {
+            return Err(Error::BelowMinimumStake);
+        }
+
+        let token_client = token::Client::new(&env, &config.staking_token);
+        token_client.transfer(&staker, &env.current_contract_address(), &amount);
+
+        let now = env.ledger().timestamp();
+        let unlock_at = now.checked_add(tier.lock_duration).ok_or(Error::Overflow)?;
+
+        let stake = StakeInfo {
+            staker: staker.clone(),
+            amount,
+            tier_id,
+            staked_at: now,
+            unlock_at,
+            claimed_rewards: 0,
+            emergency_unstaked: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stake(staker.clone()), &stake);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Stake(staker.clone()),
+            STAKE_TTL_LEDGERS,
+            STAKE_TTL_LEDGERS,
+        );
+
+        Self::adjust_total_staked(&env, amount);
+        Ok(())
+    }
+
+    /// Return full principal after the lock period has elapsed.
+    pub fn unstake_tokens(env: Env, staker: Address) -> Result<(), Error> {
+        staker.require_auth();
+
+        let config = Self::load_config(&env)?;
+
+        let stake: StakeInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Stake(staker.clone()))
+            .ok_or(Error::StakeNotFound)?;
+
+        let now = env.ledger().timestamp();
+        if now < stake.unlock_at {
+            return Err(Error::StillLocked);
+        }
+
+        let token_client = token::Client::new(&env, &config.staking_token);
+        token_client.transfer(&env.current_contract_address(), &staker, &stake.amount);
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Stake(staker.clone()));
+        Self::adjust_total_staked(&env, -stake.amount);
+        Ok(())
+    }
+
+    /// Emergency unstake: return `amount - penalty` immediately (no rewards).
+    /// The penalty stays in the contract until an admin calls
+    /// `withdraw_penalties`.
+    pub fn emergency_unstake(env: Env, staker: Address) -> Result<(), Error> {
+        staker.require_auth();
+
+        let config = Self::load_config(&env)?;
+
+        let stake: StakeInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Stake(staker.clone()))
+            .ok_or(Error::StakeNotFound)?;
+
+        let penalty = stake
+            .amount
+            .checked_mul(config.emergency_unstake_penalty_bps as i128)
+            .ok_or(Error::Overflow)?
+            .checked_div(10_000)
+            .ok_or(Error::Overflow)?;
+
+        let amount_returned = stake.amount.checked_sub(penalty).ok_or(Error::Overflow)?;
+
+        let token_client = token::Client::new(&env, &config.staking_token);
+        if amount_returned > 0 {
+            token_client.transfer(&env.current_contract_address(), &staker, &amount_returned);
+        }
+        // Penalty is intentionally left in the contract.
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Stake(staker.clone()));
+        // Reduce total_staked by the FULL original amount so that the penalty
+        // remainder is correctly reflected in the contract balance surplus.
+        Self::adjust_total_staked(&env, -stake.amount);
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Queries
+    // -----------------------------------------------------------------------
+
+    pub fn get_stake_info(env: Env, staker: Address) -> Option<StakeInfo> {
+        env.storage().persistent().get(&DataKey::Stake(staker))
+    }
+
+    pub fn get_staking_config(env: Env) -> Result<StakingConfig, Error> {
+        Self::load_config(&env)
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    fn assert_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        stored.require_auth();
+        if stored != *caller {
+            return Err(Error::Unauthorized);
+        }
+        Ok(())
+    }
+
+    fn load_config(env: &Env) -> Result<StakingConfig, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(Error::StakingNotConfigured)
+    }
+
+    fn adjust_total_staked(env: &Env, delta: i128) {
+        let current: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalStaked)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalStaked, &current.saturating_add(delta));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests;

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -1,0 +1,256 @@
+//! Unit tests for the standalone staking contract.
+//!
+//! Covered scenarios
+//! -----------------
+//! 1. `test_stake_with_valid_tier_and_amount_succeeds`
+//!    A staker deposits 5 000 tokens into a tier with a 1 000 minimum;
+//!    the resulting StakeInfo must record the correct amount.
+//!
+//! 2. `test_emergency_unstake_within_lock_period_applies_penalty`
+//!    Emergency unstake immediately after staking (lock still active) must
+//!    deduct the configured 10 % penalty and return only 90 % to the staker.
+//!
+//! 3. `test_emergency_penalty_at_zero_bps_is_rejected_at_config_time`
+//!    `set_staking_config` must reject a config whose
+//!    `emergency_unstake_penalty_bps` is 0 (below the 100 bps minimum).
+//!
+//! 4. `test_normal_unstake_after_lock_period_has_zero_penalty`
+//!    After the lock period expires a normal `unstake_tokens` call must
+//!    return the full principal with no deduction.
+//!
+//! 5. `test_penalty_stays_in_contract_until_admin_withdraws`
+//!    After an emergency unstake the penalty amount must remain inside the
+//!    contract.  Only when the admin calls `withdraw_penalties` is the
+//!    surplus transferred to the designated recipient.
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use crate::{StakingConfig, StakingContract, StakingContractClient, StakingTier};
+
+// ---------------------------------------------------------------------------
+// Shared helper
+// ---------------------------------------------------------------------------
+
+/// Register the staking contract, set an admin, mint `mint_amount` tokens to
+/// `staker`, configure a 10 % emergency penalty, and create a single "bronze"
+/// tier (min 1 000 tokens, 1-day lock).
+///
+/// Returns `(client, admin, staker, staking_token_address,
+///           staking_asset_client)` so each test can operate independently.
+fn setup<'a>(
+    env: &'a Env,
+    mint_amount: i128,
+) -> (
+    StakingContractClient<'a>,
+    Address,
+    Address,
+    Address,
+    soroban_sdk::token::StellarAssetClient<'a>,
+) {
+    let contract_id = env.register(StakingContract, ());
+    let client = StakingContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let staker = Address::generate(env);
+
+    client.set_admin(&admin);
+
+    // Register two separate token contracts (staking token + reward pool).
+    let staking_token = env.register_stellar_asset_contract_v2(admin.clone());
+    let reward_token = env.register_stellar_asset_contract_v2(admin.clone());
+
+    let sac = soroban_sdk::token::StellarAssetClient::new(env, &staking_token.address());
+    sac.mint(&staker, &mint_amount);
+
+    let config = StakingConfig {
+        staking_enabled: true,
+        emergency_unstake_penalty_bps: 1_000, // 10 %
+        staking_token: staking_token.address(),
+        reward_pool: reward_token.address(),
+    };
+    client.set_staking_config(&admin, &config).unwrap();
+
+    let tier = StakingTier {
+        id: String::from_str(env, "bronze"),
+        name: String::from_str(env, "Bronze"),
+        min_stake_amount: 1_000,
+        lock_duration: 86_400, // 1 day in seconds
+        reward_multiplier_bps: 10_000,
+        base_rate_bps: 500,
+    };
+    client.create_staking_tier(&admin, &tier).unwrap();
+
+    (client, admin, staker, staking_token.address(), sac)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Staking 5 000 tokens into the "bronze" tier (min 1 000) must succeed and
+/// the resulting StakeInfo must record the correct staker address and amount.
+#[test]
+fn test_stake_with_valid_tier_and_amount_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, staker, _token, _sac) = setup(&env, 10_000);
+
+    client
+        .stake_tokens(&staker, &String::from_str(&env, "bronze"), &5_000)
+        .unwrap();
+
+    let info = client
+        .get_stake_info(&staker)
+        .expect("StakeInfo must exist after staking");
+
+    assert_eq!(info.staker, staker);
+    assert_eq!(info.amount, 5_000);
+    assert_eq!(info.tier_id, String::from_str(&env, "bronze"));
+    assert!(!info.emergency_unstaked);
+}
+
+/// Emergency-unstaking while still in the lock window must apply the 10 %
+/// penalty: staker receives 9 000 out of a 10 000 stake.
+#[test]
+fn test_emergency_unstake_within_lock_period_applies_penalty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, staker, staking_token, _sac) = setup(&env, 10_000);
+
+    client
+        .stake_tokens(&staker, &String::from_str(&env, "bronze"), &10_000)
+        .unwrap();
+
+    // Lock period has NOT elapsed — emergency_unstake should still succeed.
+    client.emergency_unstake(&staker).unwrap();
+
+    // Stake record must be cleared.
+    assert!(
+        client.get_stake_info(&staker).is_none(),
+        "stake record must be removed after emergency unstake"
+    );
+
+    // Verify the staker received exactly (10 000 - 10 %) = 9 000 tokens.
+    let token_client = soroban_sdk::token::Client::new(&env, &staking_token);
+    let staker_balance = token_client.balance(&staker);
+    assert_eq!(
+        staker_balance, 9_000,
+        "staker must receive principal minus 10 % penalty"
+    );
+}
+
+/// `set_staking_config` must return an error when
+/// `emergency_unstake_penalty_bps` is 0 — below the 100 bps floor.
+#[test]
+fn test_emergency_penalty_at_zero_bps_is_rejected_at_config_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(StakingContract, ());
+    let client = StakingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    let staking_token = env.register_stellar_asset_contract_v2(admin.clone());
+    let reward_token = env.register_stellar_asset_contract_v2(admin.clone());
+
+    let bad_config = StakingConfig {
+        staking_enabled: true,
+        emergency_unstake_penalty_bps: 0, // invalid — must be rejected
+        staking_token: staking_token.address(),
+        reward_pool: reward_token.address(),
+    };
+
+    let result = client.try_set_staking_config(&admin, &bad_config);
+    assert!(
+        result.is_err(),
+        "zero-bps penalty must be rejected at config time"
+    );
+}
+
+/// After the lock period has elapsed, `unstake_tokens` must return the full
+/// principal with no deduction.
+#[test]
+fn test_normal_unstake_after_lock_period_has_zero_penalty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, staker, staking_token, _sac) = setup(&env, 10_000);
+
+    client
+        .stake_tokens(&staker, &String::from_str(&env, "bronze"), &5_000)
+        .unwrap();
+
+    // Advance the ledger timestamp past the 1-day lock duration.
+    env.ledger().with_mut(|li| {
+        li.timestamp += 86_400 + 1;
+    });
+
+    client.unstake_tokens(&staker).unwrap();
+
+    // Stake record must be cleared.
+    assert!(
+        client.get_stake_info(&staker).is_none(),
+        "stake record must be removed after normal unstake"
+    );
+
+    // The staker deposited 5 000 and started with 10 000; they should have
+    // the full 10 000 back (5 000 remaining + 5 000 returned).
+    let token_client = soroban_sdk::token::Client::new(&env, &staking_token);
+    let staker_balance = token_client.balance(&staker);
+    assert_eq!(
+        staker_balance, 10_000,
+        "full principal must be returned on normal unstake"
+    );
+}
+
+/// The penalty (10 % of 10 000 = 1 000) must remain inside the contract
+/// after an emergency unstake.  Only after the admin calls
+/// `withdraw_penalties` should the recipient receive those 1 000 tokens.
+#[test]
+fn test_penalty_stays_in_contract_until_admin_withdraws() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, staker, staking_token, _sac) = setup(&env, 10_000);
+
+    client
+        .stake_tokens(&staker, &String::from_str(&env, "bronze"), &10_000)
+        .unwrap();
+
+    client.emergency_unstake(&staker).unwrap();
+
+    let token_client = soroban_sdk::token::Client::new(&env, &staking_token);
+
+    // After emergency unstake the contract balance must equal the retained
+    // penalty (1 000 tokens = 10 % of 10 000).
+    // `client.address()` is the actual staking contract address.
+    let contract_balance = token_client.balance(client.address());
+    assert_eq!(
+        contract_balance, 1_000,
+        "penalty must stay in the contract until admin withdraws"
+    );
+
+    // Now the admin withdraws the penalty to a fresh recipient address.
+    let recipient = Address::generate(&env);
+    client.withdraw_penalties(&admin, &recipient).unwrap();
+
+    // Recipient must have received exactly the penalty amount.
+    let recipient_balance = token_client.balance(&recipient);
+    assert_eq!(
+        recipient_balance, 1_000,
+        "recipient must receive the full penalty after admin withdrawal"
+    );
+
+    // Contract balance must now be zero.
+    let contract_balance_after = token_client.balance(client.address());
+    assert_eq!(
+        contract_balance_after, 0,
+        "contract balance must be zero after penalty withdrawal"
+    );
+}


### PR DESCRIPTION
Creates a standalone `contracts/staking/` crate with unit tests covering the five scenarios specified in the issue.

## Changes

- `contracts/staking/Cargo.toml`: new staking crate added to workspace
- `contracts/staking/src/lib.rs`: self-contained staking contract with StakingConfig/StakingTier/StakeInfo types and staking entrypoints
- `contracts/staking/src/tests.rs`: five unit tests — valid stake succeeds, emergency unstake applies penalty, zero-bps penalty rejected at config time, normal unstake after lock has no penalty, penalty stays in contract until admin withdraws
- `contracts/Cargo.toml`: added "staking" to workspace members

Closes #407