### PR TITLE
feat: add admin-only contract upgrade

### DIFF
--- a/contracts/certificates/src/lib.rs
+++ b/contracts/certificates/src/lib.rs
@@ -11,8 +11,8 @@ mod test;
 pub use errors::ContractError;
 pub use types::Certificate;
 
-use soroban_sdk::{contract, contractimpl, symbol_short, xdr::ToXdr, Address, Bytes, Env};
-use storage::{MIN_TTL, MAX_TTL};
+use soroban_sdk::{contract, contractimpl, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env};
+use storage::{MAX_TTL, MIN_TTL};
 
 #[contract]
 pub struct CertificateContract;
@@ -60,8 +60,8 @@ impl CertificateContract {
             return Err(ContractError::CertificateExists);
         }
 
-        let backend_public_key = storage::get_backend_pubkey(&env)
-            .ok_or(ContractError::NotInitialized)?;
+        let backend_public_key =
+            storage::get_backend_pubkey(&env).ok_or(ContractError::NotInitialized)?;
 
         let payload = (wallet.clone(), course_id).to_xdr(&env);
         verify::verify_backend_proof(&env, &backend_public_key, &payload, &proof)?;
@@ -116,5 +116,17 @@ impl CertificateContract {
         _course_id: u64,
     ) -> Result<(), ContractError> {
         Err(ContractError::SoulboundTransferNotAllowed)
+    }
+
+    /// Admin-only: upgrade the current contract to `new_wasm_hash`.
+    pub fn upgrade(
+        env: Env,
+        admin: Address,
+        new_wasm_hash: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::require_admin(&env, &admin)?;
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 }

--- a/contracts/chainverse-core/src/lib.rs
+++ b/contracts/chainverse-core/src/lib.rs
@@ -34,7 +34,7 @@ use analytics::{
 };
 use storage::DataKey;
 
-use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Vec};
 
 const CONTRACT_VERSION: &str = "1.0.0";
 
@@ -67,7 +67,9 @@ impl ChainverseCore {
         };
 
         env.storage().persistent().set(&DataKey::Config, &config);
-        env.storage().persistent().extend_ttl(&DataKey::Config, MIN_TTL, MAX_TTL);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Config, MIN_TTL, MAX_TTL);
         Ok(())
     }
 
@@ -128,8 +130,21 @@ impl ChainverseCore {
         }
 
         env.storage().persistent().set(&DataKey::Config, &config);
-        env.storage().persistent().extend_ttl(&DataKey::Config, MIN_TTL, MAX_TTL);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Config, MIN_TTL, MAX_TTL);
         analytics::record(&env, EVT_CONFIG_UPDATED);
+        Ok(())
+    }
+
+    /// Admin-only: upgrade the current contract to `new_wasm_hash`.
+    pub fn upgrade(
+        env: Env,
+        caller: Address,
+        new_wasm_hash: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        admin::only_admin(&env, &caller)?;
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
     }
 
@@ -152,7 +167,8 @@ impl ChainverseCore {
 
         env.storage().persistent().set(&DataKey::Config, &config);
         analytics::record(&env, EVT_ADMIN_CHANGED);
-        env.events().publish((symbol_short!("ADM_CHNG"),), (old_admin, new_admin));
+        env.events()
+            .publish((symbol_short!("ADM_CHNG"),), (old_admin, new_admin));
         Ok(())
     }
 

--- a/contracts/chv_token/src/error.rs
+++ b/contracts/chv_token/src/error.rs
@@ -8,4 +8,5 @@ pub enum TokenError {
     NotInitialized = 1,
     InvalidAmount = 2,
     InsufficientBalance = 3,
+    Unauthorized = 4,
 }

--- a/contracts/chv_token/src/lib.rs
+++ b/contracts/chv_token/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol, Vec,
+    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, String, Symbol, Vec,
 };
 
 mod error;
@@ -25,7 +25,6 @@ pub struct CHVToken;
 
 #[contractimpl]
 impl CHVToken {
-
     /// Initialize contract and mint fixed supply to treasury
     pub fn initialize(env: Env, admin: Address) -> Result<(), TokenError> {
         if env.storage().instance().has(&DataKey::Initialized) {
@@ -40,9 +39,11 @@ impl CHVToken {
         env.storage()
             .persistent()
             .set(&DataKey::Balance(admin.clone()), &TOTAL_SUPPLY);
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Balance(admin.clone()), BALANCE_MIN_TTL, BALANCE_MAX_TTL);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Balance(admin.clone()),
+            BALANCE_MIN_TTL,
+            BALANCE_MAX_TTL,
+        );
 
         env.storage().instance().set(&DataKey::Initialized, &true);
 
@@ -85,22 +86,44 @@ impl CHVToken {
         env.storage()
             .persistent()
             .set(&DataKey::Balance(from.clone()), &(from_balance - amount));
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Balance(from), BALANCE_MIN_TTL, BALANCE_MAX_TTL);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Balance(from),
+            BALANCE_MIN_TTL,
+            BALANCE_MAX_TTL,
+        );
 
         env.storage()
             .persistent()
             .set(&DataKey::Balance(to.clone()), &(to_balance + amount));
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Balance(to), BALANCE_MIN_TTL, BALANCE_MAX_TTL);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Balance(to),
+            BALANCE_MIN_TTL,
+            BALANCE_MAX_TTL,
+        );
 
         Ok(())
     }
 
     pub fn version(env: Env) -> String {
         String::from_str(&env, CONTRACT_VERSION)
+    }
+
+    /// Admin-only: upgrade the current contract to `new_wasm_hash`.
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), TokenError> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(TokenError::NotInitialized)?;
+
+        if stored_admin != admin {
+            return Err(TokenError::Unauthorized);
+        }
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 }
 

--- a/contracts/course_registry/src/lib.rs
+++ b/contracts/course_registry/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, String,
-    Symbol,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, BytesN, Env,
+    String, Symbol,
 };
 
 const CONTRACT_VERSION: &str = "1.0.0";
@@ -42,7 +42,6 @@ pub struct CourseRegistryContract;
 
 #[contractimpl]
 impl CourseRegistryContract {
-
     // Initialize Admin (run once)
     pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
         if env.storage().instance().has(&DataKey::Admin) {
@@ -107,8 +106,7 @@ impl CourseRegistryContract {
             panic_with_error!(&env, ContractError::CourseNotFound);
         }
 
-        let mut course: Course =
-            env.storage().persistent().get(&key).unwrap();
+        let mut course: Course = env.storage().persistent().get(&key).unwrap();
 
         course.is_active = is_active;
 
@@ -133,7 +131,6 @@ impl CourseRegistryContract {
         Ok(())
     }
 
-
     // Get Course
     pub fn get_course(env: Env, course_id: Symbol) -> Course {
         let key = DataKey::Course(course_id);
@@ -157,5 +154,27 @@ impl CourseRegistryContract {
 
     pub fn version(env: Env) -> String {
         String::from_str(&env, CONTRACT_VERSION)
+    }
+
+    /// Admin-only: upgrade the current contract to `new_wasm_hash`.
+    pub fn upgrade(
+        env: Env,
+        admin: Address,
+        new_wasm_hash: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+
+        if stored_admin != admin {
+            return Err(ContractError::NotAdmin);
+        }
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 }

--- a/contracts/escrow-vault/src/lib.rs
+++ b/contracts/escrow-vault/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, Vec};
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -10,10 +10,10 @@ use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum VaultError {
-    NotFound      = 1,
-    NotPending    = 2,
-    Unauthorized  = 3,
-    AlreadyVoted  = 4,
+    NotFound = 1,
+    NotPending = 2,
+    Unauthorized = 3,
+    AlreadyVoted = 4,
 }
 
 // ---------------------------------------------------------------------------
@@ -31,17 +31,18 @@ pub enum VaultStatus {
 #[contracttype]
 #[derive(Clone)]
 pub struct Vault {
-    pub depositor:  Address,
-    pub recipient:  Address,
-    pub token:      Address,
-    pub amount:     i128,
-    pub approvers:  Vec<Address>,
-    pub approvals:  Vec<Address>,
-    pub status:     VaultStatus,
+    pub depositor: Address,
+    pub recipient: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub approvers: Vec<Address>,
+    pub approvals: Vec<Address>,
+    pub status: VaultStatus,
 }
 
 #[contracttype]
 pub enum DataKey {
+    Admin,
     Vault(u64),
     NextId,
 }
@@ -55,6 +56,16 @@ pub struct EscrowVault;
 
 #[contractimpl]
 impl EscrowVault {
+    /// Sets or rotates the contract admin.
+    pub fn set_admin(env: Env, admin: Address) {
+        if let Some(current_admin) = env.storage().instance().get::<_, Address>(&DataKey::Admin) {
+            current_admin.require_auth();
+        } else {
+            admin.require_auth();
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
     /// Create a new vault. The depositor provides the approver set.
     pub fn create_vault(
         env: Env,
@@ -92,8 +103,11 @@ impl EscrowVault {
         env.storage().persistent().set(&DataKey::Vault(id), &vault);
 
         // Pull funds from depositor into the contract
-        soroban_sdk::token::Client::new(&env, &token)
-            .transfer(&depositor, &env.current_contract_address(), &amount);
+        soroban_sdk::token::Client::new(&env, &token).transfer(
+            &depositor,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         id
     }
@@ -128,11 +142,16 @@ impl EscrowVault {
         // Release when all approvers have signed off
         if vault.approvals.len() == vault.approvers.len() {
             vault.status = VaultStatus::Released;
-            soroban_sdk::token::Client::new(&env, &vault.token)
-                .transfer(&env.current_contract_address(), &vault.recipient, &vault.amount);
+            soroban_sdk::token::Client::new(&env, &vault.token).transfer(
+                &env.current_contract_address(),
+                &vault.recipient,
+                &vault.amount,
+            );
         }
 
-        env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Vault(vault_id), &vault);
         Ok(())
     }
 
@@ -159,11 +178,16 @@ impl EscrowVault {
         }
 
         // Return funds to depositor
-        soroban_sdk::token::Client::new(&env, &vault.token)
-            .transfer(&env.current_contract_address(), &vault.depositor, &vault.amount);
+        soroban_sdk::token::Client::new(&env, &vault.token).transfer(
+            &env.current_contract_address(),
+            &vault.depositor,
+            &vault.amount,
+        );
 
         vault.status = VaultStatus::Cancelled;
-        env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Vault(vault_id), &vault);
 
         env.events().publish(
             (soroban_sdk::symbol_short!("cancelled"), vault_id),
@@ -184,6 +208,24 @@ impl EscrowVault {
             .unwrap_or(0u64);
         env.storage().instance().set(&DataKey::NextId, &(id + 1));
         id
+    }
+
+    /// Admin-only: upgrade the current contract to `new_wasm_hash`.
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), VaultError> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(VaultError::Unauthorized)?;
+
+        if stored_admin != admin {
+            return Err(VaultError::Unauthorized);
+        }
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 }
 
@@ -246,8 +288,8 @@ mod test {
 
         let depositor = Address::generate(&env);
         let recipient = Address::generate(&env);
-        let token     = Address::generate(&env);
-        let approver  = Address::generate(&env);
+        let token = Address::generate(&env);
+        let approver = Address::generate(&env);
 
         let vault_id = client.create_vault(
             &depositor,
@@ -262,7 +304,10 @@ mod test {
 
         // Second approval attempt should fail with NotPending
         let result = client.try_approve_release(&approver, &vault_id);
-        assert!(result.is_err(), "approve_release on already released escrow must fail");
+        assert!(
+            result.is_err(),
+            "approve_release on already released escrow must fail"
+        );
         if let Err(err) = result {
             assert_eq!(err, VaultError::NotPending);
         }
@@ -273,11 +318,11 @@ mod test {
     fn test_approve_release_from_unauthorised_caller_is_rejected() {
         let (env, client) = setup();
 
-        let depositor  = Address::generate(&env);
-        let recipient  = Address::generate(&env);
-        let token      = Address::generate(&env);
-        let approver   = Address::generate(&env);
-        let outsider   = Address::generate(&env); // NOT in approver set
+        let depositor = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token = Address::generate(&env);
+        let approver = Address::generate(&env);
+        let outsider = Address::generate(&env); // NOT in approver set
 
         let vault_id = client.create_vault(
             &depositor,
@@ -289,7 +334,10 @@ mod test {
 
         // Outsider attempts to approve — must fail with Unauthorized
         let result = client.try_approve_release(&outsider, &vault_id);
-        assert!(result.is_err(), "approve_release from non-approver must be rejected");
+        assert!(
+            result.is_err(),
+            "approve_release from non-approver must be rejected"
+        );
 
         // Vault must still be Pending — no fund movement
         let vault = client.get_vault(&vault_id);
@@ -303,8 +351,8 @@ mod test {
 
         let depositor = Address::generate(&env);
         let recipient = Address::generate(&env);
-        let token     = Address::generate(&env);
-        let approver  = Address::generate(&env);
+        let token = Address::generate(&env);
+        let approver = Address::generate(&env);
 
         let vault_id = client.create_vault(
             &depositor,
@@ -326,9 +374,9 @@ mod test {
 
         let depositor = Address::generate(&env);
         let recipient = Address::generate(&env);
-        let token     = Address::generate(&env);
-        let a1        = Address::generate(&env);
-        let a2        = Address::generate(&env);
+        let token = Address::generate(&env);
+        let a1 = Address::generate(&env);
+        let a2 = Address::generate(&env);
 
         let vault_id = client.create_vault(
             &depositor,

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -12,7 +12,7 @@ mod version;
 pub use errors::EscrowError;
 pub use types::{Escrow, EscrowStatus};
 
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
 
 #[contract]
 pub struct EscrowContract;
@@ -31,11 +31,22 @@ impl EscrowContract {
         Ok(())
     }
 
-        // Ensure an admin is set and has authorized this call
-        let admin = storage::get_admin(&env).ok_or(EscrowError::Unauthorized)?;
-        admin.require_auth();
+    /// Whitelist a token for escrow creation. Admin-only.
+    pub fn whitelist_token(env: Env, token: Address) -> Result<(), EscrowError> {
+        storage::require_admin(&env)?;
         storage::whitelist_token(&env, &token);
         Ok(())
+    }
+
+    /// Admin-only: upgrade the current contract to `new_wasm_hash`.
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), EscrowError> {
+        let stored_admin = storage::require_admin(&env)?;
+        if stored_admin != admin {
+            return Err(EscrowError::Unauthorized);
+        }
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
+    }
 
     /// Create a new escrow. Transfers `amount` of `token` from `buyer` into
     /// the contract and returns the new escrow ID.
@@ -81,7 +92,6 @@ impl EscrowContract {
     pub fn get_escrow_count(env: Env) -> u64 {
         storage::get_escrow_count(&env)
     }
-
 
     /// Flag an escrow as disputed. Only the buyer or seller can raise a dispute.
     /// Prevents automatic release until resolved.

--- a/contracts/escrow/tests/test_full_flow.rs
+++ b/contracts/escrow/tests/test_full_flow.rs
@@ -1,17 +1,18 @@
 #![cfg(test)]
 
-extern crate soroban_sdk;
-use crate::{EscrowContract, EscrowContractClient, EscrowError};
+use escrow::{EscrowContract, EscrowContractClient, EscrowError};
 use soroban_sdk::{Env, String};
 
 #[test]
-use soroban_sdk::{Address, Env, String};
-
-#[test]
 fn e2e_escrow_version_and_count_baseline() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
 
-use crate::{EscrowContract, EscrowContractClient, EscrowError};
-use soroban_sdk::{Address, Env, String};
+    assert_eq!(client.version(), String::from_str(&env, "1.0.0"));
+    assert_eq!(client.get_escrow_count(), 0);
+    assert_eq!(client.get_total_volume(), 0);
+}
 
 #[test]
 fn e2e_escrow_version_and_dispute_baseline() {
@@ -24,15 +25,4 @@ fn e2e_escrow_version_and_dispute_baseline() {
         client.try_resolve_dispute(&1, &true),
         Err(Ok(EscrowError::DisputeResolutionNotImplemented))
     );
-    assert_eq!(client.get_escrow_count(), 0u64);
-}
-
-#[test]
-fn e2e_escrow_count_starts_at_zero() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, EscrowContract);
-    let client = EscrowContractClient::new(&env, &contract_id);
-
-    assert_eq!(client.get_escrow_count(), 0);
-    assert_eq!(client.get_total_volume(), 0);
 }

--- a/contracts/payout-automation/src/lib.rs
+++ b/contracts/payout-automation/src/lib.rs
@@ -1,13 +1,12 @@
 #![no_std]
 
 const MAX_BATCH_SIZE: u32 = 100;
-const AUTH_MIN_TTL: u32 = 17_280;   // ~1 day
-const AUTH_MAX_TTL: u32 = 518_400;  // ~30 days
+const AUTH_MIN_TTL: u32 = 17_280; // ~1 day
+const AUTH_MAX_TTL: u32 = 518_400; // ~30 days
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, contracterror,
-    token::Client as TokenClient,
-    symbol_short, Address, Env, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short,
+    token::Client as TokenClient, Address, BytesN, Env, Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -18,7 +17,7 @@ use soroban_sdk::{
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum PayoutError {
-    Unauthorized  = 1,
+    Unauthorized = 1,
     NotInitialized = 2,
     BatchTooLarge = 3,
 }
@@ -32,7 +31,7 @@ pub enum PayoutError {
 #[derive(Clone)]
 pub struct PayoutEntry {
     pub recipient: Address,
-    pub amount:    i128,
+    pub amount: i128,
 }
 
 #[contracttype]
@@ -59,7 +58,9 @@ impl PayoutAutomation {
         env.storage().instance().set(&DataKey::Admin, &admin);
         let auth_key = DataKey::Authorised(admin);
         env.storage().persistent().set(&auth_key, &true);
-        env.storage().persistent().extend_ttl(&auth_key, AUTH_MIN_TTL, AUTH_MAX_TTL);
+        env.storage()
+            .persistent()
+            .extend_ttl(&auth_key, AUTH_MIN_TTL, AUTH_MAX_TTL);
     }
 
     /// Admin-only: add an address to the authorised set.
@@ -68,7 +69,9 @@ impl PayoutAutomation {
         Self::only_admin(&env, &admin)?;
         let auth_key = DataKey::Authorised(caller);
         env.storage().persistent().set(&auth_key, &true);
-        env.storage().persistent().extend_ttl(&auth_key, AUTH_MIN_TTL, AUTH_MAX_TTL);
+        env.storage()
+            .persistent()
+            .extend_ttl(&auth_key, AUTH_MIN_TTL, AUTH_MAX_TTL);
         Ok(())
     }
 
@@ -76,7 +79,9 @@ impl PayoutAutomation {
     pub fn remove_authorised(env: Env, admin: Address, caller: Address) -> Result<(), PayoutError> {
         admin.require_auth();
         Self::only_admin(&env, &admin)?;
-        env.storage().persistent().remove(&DataKey::Authorised(caller));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Authorised(caller));
         Ok(())
     }
 
@@ -123,6 +128,14 @@ impl PayoutAutomation {
         Ok(())
     }
 
+    /// Admin-only: upgrade the current contract to `new_wasm_hash`.
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), PayoutError> {
+        admin.require_auth();
+        Self::only_admin(&env, &admin)?;
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
+    }
+
     // -----------------------------------------------------------------------
     // Internal
     // -----------------------------------------------------------------------
@@ -166,8 +179,8 @@ mod test {
         amount: i128,
     ) -> (
         Env,
-        Address,                          // admin / authorised caller
-        Address,                          // token address
+        Address, // admin / authorised caller
+        Address, // token address
         PayoutAutomationClient<'static>,
     ) {
         let env = Env::default();
@@ -197,8 +210,14 @@ mod test {
 
         let payouts = vec![
             &env,
-            PayoutEntry { recipient: r1.clone(), amount: 300 },
-            PayoutEntry { recipient: r2.clone(), amount: 700 },
+            PayoutEntry {
+                recipient: r1.clone(),
+                amount: 300,
+            },
+            PayoutEntry {
+                recipient: r2.clone(),
+                amount: 700,
+            },
         ];
 
         client.execute(&admin, &token_addr, &payouts);
@@ -213,16 +232,22 @@ mod test {
     fn test_execute_from_unauthorised_caller_is_rejected() {
         let (env, _admin, token_addr, client) = setup(1000);
 
-        let outsider  = Address::generate(&env);
+        let outsider = Address::generate(&env);
         let recipient = Address::generate(&env);
 
         let payouts = vec![
             &env,
-            PayoutEntry { recipient: recipient.clone(), amount: 100 },
+            PayoutEntry {
+                recipient: recipient.clone(),
+                amount: 100,
+            },
         ];
 
         let result = client.try_execute(&outsider, &token_addr, &payouts);
-        assert!(result.is_err(), "execute from non-authorised caller must be rejected");
+        assert!(
+            result.is_err(),
+            "execute from non-authorised caller must be rejected"
+        );
 
         // No funds must have moved
         let tc = TokenClient::new(&env, &token_addr);
@@ -252,9 +277,18 @@ mod test {
 
         let payouts = vec![
             &env,
-            PayoutEntry { recipient: recipient.clone(), amount: 0 },
-            PayoutEntry { recipient: recipient.clone(), amount: -10 },
-            PayoutEntry { recipient: recipient.clone(), amount: 250 },
+            PayoutEntry {
+                recipient: recipient.clone(),
+                amount: 0,
+            },
+            PayoutEntry {
+                recipient: recipient.clone(),
+                amount: -10,
+            },
+            PayoutEntry {
+                recipient: recipient.clone(),
+                amount: 250,
+            },
         ];
 
         client.execute(&admin, &token_addr, &payouts);

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, Env, String,
+    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, String,
 };
 
 // ---------------------------------------------------------------------------
@@ -309,6 +309,13 @@ impl StakingContract {
 
     pub fn get_staking_config(env: Env) -> Result<StakingConfig, Error> {
         Self::load_config(&env)
+    }
+
+    /// Admin-only: upgrade the current contract to `new_wasm_hash`.
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
+        Self::assert_admin(&env, &admin)?;
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- Add admin-only `upgrade(...)` entrypoints to contracts so deployed addresses can be upgraded in-place using `env.deployer().update_current_contract_wasm(new_wasm_hash)`.

Validation:
- `cargo test --workspace --features testutils` currently fails due to a dependency resolution conflict (`soroban-sdk v22.0.0` vs `ed25519-dalek =2.0.0` pinned in `contracts/certificates`; pre-existing).

Closes #391