### PR TITLE
[codex] Guard reward backend pubkey rotation before init

### DIFF
--- a/contracts/reward/src/lib.rs
+++ b/contracts/reward/src/lib.rs
@@ -10,6 +10,9 @@ mod events;
 mod admin;
 mod crypto;
 
+#[cfg(test)]
+mod test;
+
 use storage::{set_treasury, set_token, set_reward_amount, MIN_TTL, MAX_TTL};
 pub use crate::storage::DataKey;
 use admin::require_admin;
@@ -45,6 +48,9 @@ impl RewardContract {
 
     pub fn rotate_backend_pubkey(env: Env, new_pubkey: BytesN<32>) -> Result<(), Error> {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        if !env.storage().instance().has(&DataKey::Initialized) {
+            return Err(Error::NotInitialized);
+        }
         require_admin(&env)?;
         env.storage().instance().set(&DataKey::BackendPubKey, &new_pubkey);
         Ok(())

--- a/contracts/reward/src/test.rs
+++ b/contracts/reward/src/test.rs
@@ -1,4 +1,14 @@
-#[cfg(test)]
-mod test {
-    use super::*;
+use super::*;
+use soroban_sdk::{BytesN, Env};
+
+#[test]
+fn rotate_backend_pubkey_before_initialize_returns_not_initialized() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardContract);
+    let client = RewardContractClient::new(&env, &contract_id);
+    let new_pubkey = BytesN::from_array(&env, &[7; 32]);
+
+    let result = client.try_rotate_backend_pubkey(&new_pubkey);
+
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
 }


### PR DESCRIPTION
Closes #421.

Summary:
- Added an initialization guard to `rotate_backend_pubkey` so it returns `Error::NotInitialized` before attempting admin authorization on an uninitialized contract.
- Added a unit test covering the uninitialized rotate path and wired `contracts/reward/src/test.rs` into the reward contract module.

Validation:
- Added the regression test before the production guard.
- Ran `git diff --check` successfully.
- Confirmed `contracts/reward` is not listed in `contracts/Cargo.toml` workspace members.
- `cargo` is unavailable in this environment, so Rust tests could not be executed locally.