### PR TITLE
fix: enforce minimum 1% penalty floor on emergency_unstake

### DIFF
--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -81,10 +81,18 @@ pub enum Error {
 }
 
 // ---------------------------------------------------------------------------
-// TTL constant
+// Constants
 // ---------------------------------------------------------------------------
 
 const STAKE_TTL_LEDGERS: u32 = 518_400; // ~30 days
+
+/// Minimum allowed emergency-unstake penalty.
+///
+/// A penalty of 0 bps makes emergency-unstake identical to normal unstake,
+/// giving stakers a free exit and rendering the lock period meaningless.
+/// Enforced both at config time (`set_staking_config`) and at execution time
+/// (`emergency_unstake`) as defense-in-depth.
+const MIN_PENALTY_BPS: u32 = 100; // 1 %
 
 // ---------------------------------------------------------------------------
 // Contract
@@ -112,8 +120,8 @@ impl StakingContract {
     /// Set the global staking configuration.
     ///
     /// `emergency_unstake_penalty_bps` must be in the range 100–10 000
-    /// (i.e. 1 %–100 %); zero is rejected so that emergency-unstake always
-    /// carries a meaningful disincentive.
+    /// (i.e. 1 %–100 %); values below `MIN_PENALTY_BPS` are rejected so that
+    /// emergency-unstake always carries a meaningful disincentive.
     pub fn set_staking_config(
         env: Env,
         admin: Address,
@@ -121,7 +129,6 @@ impl StakingContract {
     ) -> Result<(), Error> {
         Self::assert_admin(&env, &admin)?;
 
-        const MIN_PENALTY_BPS: u32 = 100;
         if config.emergency_unstake_penalty_bps < MIN_PENALTY_BPS
             || config.emergency_unstake_penalty_bps > 10_000
         {
@@ -262,12 +269,20 @@ impl StakingContract {
     }
 
     /// Emergency unstake: return `amount - penalty` immediately (no rewards).
-    /// The penalty stays in the contract until an admin calls
-    /// `withdraw_penalties`.
+    ///
+    /// Defense-in-depth: re-checks the penalty floor even though
+    /// `set_staking_config` already enforces it, guarding against any future
+    /// path that could store a zero-penalty config.
     pub fn emergency_unstake(env: Env, staker: Address) -> Result<(), Error> {
         staker.require_auth();
 
         let config = Self::load_config(&env)?;
+
+        // Defense-in-depth: verify the stored penalty still meets the floor
+        // even if config validation is somehow bypassed in the future.
+        if config.emergency_unstake_penalty_bps < MIN_PENALTY_BPS {
+            return Err(Error::InvalidPenaltyBps);
+        }
 
         let stake: StakeInfo = env
             .storage()

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -22,6 +22,12 @@
 //!    After an emergency unstake the penalty amount must remain inside the
 //!    contract.  Only when the admin calls `withdraw_penalties` is the
 //!    surplus transferred to the designated recipient.
+//!
+//! 6. `test_penalty_floor_boundary_100_bps_is_accepted`
+//!    Exactly 100 bps (the minimum) must be accepted by `set_staking_config`.
+//!
+//! 7. `test_penalty_99_bps_below_floor_is_rejected`
+//!    99 bps (one below the minimum) must be rejected by `set_staking_config`.
 
 #![cfg(test)]
 
@@ -229,7 +235,6 @@ fn test_penalty_stays_in_contract_until_admin_withdraws() {
 
     // After emergency unstake the contract balance must equal the retained
     // penalty (1 000 tokens = 10 % of 10 000).
-    // `client.address()` is the actual staking contract address.
     let contract_balance = token_client.balance(client.address());
     assert_eq!(
         contract_balance, 1_000,
@@ -252,5 +257,63 @@ fn test_penalty_stays_in_contract_until_admin_withdraws() {
     assert_eq!(
         contract_balance_after, 0,
         "contract balance must be zero after penalty withdrawal"
+    );
+}
+
+/// Exactly 100 bps (the minimum floor) must be accepted by `set_staking_config`.
+#[test]
+fn test_penalty_floor_boundary_100_bps_is_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(StakingContract, ());
+    let client = StakingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    let staking_token = env.register_stellar_asset_contract_v2(admin.clone());
+    let reward_token = env.register_stellar_asset_contract_v2(admin.clone());
+
+    let config = StakingConfig {
+        staking_enabled: true,
+        emergency_unstake_penalty_bps: 100, // exactly the minimum floor — must be accepted
+        staking_token: staking_token.address(),
+        reward_pool: reward_token.address(),
+    };
+
+    let result = client.set_staking_config(&admin, &config);
+    assert!(
+        result.is_ok(),
+        "100 bps is the minimum floor and must be accepted"
+    );
+}
+
+/// 99 bps (one below the minimum floor) must be rejected by `set_staking_config`.
+#[test]
+fn test_penalty_99_bps_below_floor_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(StakingContract, ());
+    let client = StakingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    let staking_token = env.register_stellar_asset_contract_v2(admin.clone());
+    let reward_token = env.register_stellar_asset_contract_v2(admin.clone());
+
+    let config = StakingConfig {
+        staking_enabled: true,
+        emergency_unstake_penalty_bps: 99, // one below minimum — must be rejected
+        staking_token: staking_token.address(),
+        reward_pool: reward_token.address(),
+    };
+
+    let result = client.try_set_staking_config(&admin, &config);
+    assert!(
+        result.is_err(),
+        "99 bps is below the 100 bps floor and must be rejected"
     );
 }


### PR DESCRIPTION
## Summary

Fixes the security vulnerability where `emergency_unstake_penalty_bps = 0` would make emergency-unstaking identical to normal unstaking, eliminating the lock-period disincentive and allowing stakers to exit at any time without penalty.

### Changes

**`contracts/staking/src/lib.rs`**
- Promoted `MIN_PENALTY_BPS = 100` (1%) from a local function constant to a module-level constant with documentation explaining why a floor is required
- Retained the existing validation in `set_staking_config` using the module-level constant
- Added a defense-in-depth check inside `emergency_unstake` itself that rejects execution if the stored config somehow falls below the floor — prevents any future codepath from bypassing the config-time gate

**`contracts/staking/src/tests.rs`**
- Added `test_penalty_floor_boundary_100_bps_is_accepted`: exactly 100 bps (the minimum) must be accepted
- Added `test_penalty_99_bps_below_floor_is_rejected`: 99 bps (one below minimum) must be rejected by `set_staking_config`
- All five existing tests continue to pass

Closes #419