### PR TITLE
fix(escrow): validate amount > 0 in create_escrow

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -285,6 +285,22 @@ mod test {
         assert_eq!(result, Err(Ok(EscrowError::InvalidParties)));
     }
 
+    #[test]
+    fn test_create_escrow_rejects_zero_amount() {
+        let (_env, buyer, seller, token_addr, client) = setup(1000);
+
+        let result = client.try_create_escrow(&buyer, &seller, &token_addr, &0, &9000);
+        assert_eq!(result, Err(Ok(EscrowError::InvalidAmount)));
+    }
+
+    #[test]
+    fn test_create_escrow_rejects_negative_amount() {
+        let (_env, buyer, seller, token_addr, client) = setup(1000);
+
+        let result = client.try_create_escrow(&buyer, &seller, &token_addr, &-1, &9000);
+        assert_eq!(result, Err(Ok(EscrowError::InvalidAmount)));
+    }
+
     // -----------------------------------------------------------------------
     // release_funds
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `create_escrow` function in `contracts/escrow/src/create.rs` already contains the guard:

```rust
if amount <= 0 {
    return Err(EscrowError::InvalidAmount);
}
```

This PR adds explicit unit tests to confirm that zero and negative amounts are correctly rejected, closing the gap identified in #415.

## Changes

- **`contracts/escrow/src/lib.rs`**: Added `test_create_escrow_rejects_zero_amount` and `test_create_escrow_rejects_negative_amount` tests.

## Testing

Both new tests use the existing `setup` helper and `try_create_escrow` pattern, asserting `EscrowError::InvalidAmount` is returned.

Closes #415