### PR TITLE
fix(escrow): rename ESC_CRTD→ESC_CRE and include token in escrow_created event

### DIFF
--- a/contracts/escrow/src/events.rs
+++ b/contracts/escrow/src/events.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{Address, Env, symbol_short};
 
 pub fn escrow_created(env: &Env, escrow_id: u64, buyer: &Address, seller: &Address, token: &Address, amount: i128) {
     env.events().publish(
-        (symbol_short!("ESC_CRTD"),),
+        (symbol_short!("ESC_CRE"),),
         (escrow_id, buyer.clone(), seller.clone(), token.clone(), amount),
     );
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -431,6 +431,24 @@ mod test {
     }
 
     #[test]
+    fn test_escrow_created_event_includes_token() {
+        let (env, buyer, seller, token_addr, client) = setup(1000);
+        let escrow_id = client.create_escrow(&buyer, &seller, &token_addr, &300, &9000);
+
+        // Verify ESC_CRE event is emitted with symbol as first topic
+        let sym_val = Symbol::new(&env, "ESC_CRE").into_val(&env);
+        let events = env.events().all();
+        let found = events.iter().any(|(_, topics, _)| {
+            topics.get(0).map_or(false, |v| v == sym_val)
+        });
+        assert!(found, "ESC_CRE event must be emitted by create_escrow");
+
+        // Verify the stored escrow record holds the correct token address
+        let escrow = client.get_escrow(&escrow_id);
+        assert_eq!(escrow.token, token_addr, "escrow token must match deposit token");
+    }
+
+    #[test]
     fn test_refund_buyer_fails_if_already_released() {
         // Create escrow and release it, then try to refund — must fail.
         let (env, buyer, seller, token_addr, client) = setup(1000);

--- a/contracts/escrow/test_snapshots/test/test_refund_buyer_fails_before_expiration.1.json
+++ b/contracts/escrow/test_snapshots/test/test_refund_buyer_fails_before_expiration.1.json
@@ -1238,7 +1238,7 @@
           "v0": {
             "topics": [
               {
-                "symbol": "ESC_CRTD"
+                "symbol": "ESC_CRE"
               }
             ],
             "data": {
@@ -1251,6 +1251,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
                   "i128": {

--- a/contracts/escrow/test_snapshots/test/test_refund_buyer_fails_if_already_released.1.json
+++ b/contracts/escrow/test_snapshots/test/test_refund_buyer_fails_if_already_released.1.json
@@ -1363,7 +1363,7 @@
           "v0": {
             "topics": [
               {
-                "symbol": "ESC_CRTD"
+                "symbol": "ESC_CRE"
               }
             ],
             "data": {
@@ -1376,6 +1376,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
                   "i128": {

--- a/contracts/escrow/test_snapshots/test/test_refund_buyer_success.1.json
+++ b/contracts/escrow/test_snapshots/test/test_refund_buyer_success.1.json
@@ -1291,7 +1291,7 @@
           "v0": {
             "topics": [
               {
-                "symbol": "ESC_CRTD"
+                "symbol": "ESC_CRE"
               }
             ],
             "data": {
@@ -1304,6 +1304,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
                   "i128": {

--- a/contracts/escrow/test_snapshots/test/test_release_funds_fails_if_expired.1.json
+++ b/contracts/escrow/test_snapshots/test/test_release_funds_fails_if_expired.1.json
@@ -1238,7 +1238,7 @@
           "v0": {
             "topics": [
               {
-                "symbol": "ESC_CRTD"
+                "symbol": "ESC_CRE"
               }
             ],
             "data": {
@@ -1251,6 +1251,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
                   "i128": {

--- a/contracts/escrow/test_snapshots/test/test_release_funds_fails_on_double_release.1.json
+++ b/contracts/escrow/test_snapshots/test/test_release_funds_fails_on_double_release.1.json
@@ -1363,7 +1363,7 @@
           "v0": {
             "topics": [
               {
-                "symbol": "ESC_CRTD"
+                "symbol": "ESC_CRE"
               }
             ],
             "data": {
@@ -1376,6 +1376,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
                   "i128": {

--- a/contracts/escrow/test_snapshots/test/test_release_funds_success.1.json
+++ b/contracts/escrow/test_snapshots/test/test_release_funds_success.1.json
@@ -1364,7 +1364,7 @@
           "v0": {
             "topics": [
               {
-                "symbol": "ESC_CRTD"
+                "symbol": "ESC_CRE"
               }
             ],
             "data": {
@@ -1377,6 +1377,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
                   "i128": {

--- a/contracts/escrow/test_snapshots/test/test_total_volume_increases_correctly.1.json
+++ b/contracts/escrow/test_snapshots/test/test_total_volume_increases_correctly.1.json
@@ -1452,7 +1452,7 @@
           "v0": {
             "topics": [
               {
-                "symbol": "ESC_CRTD"
+                "symbol": "ESC_CRE"
               }
             ],
             "data": {
@@ -1465,6 +1465,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
                   "i128": {
@@ -1698,7 +1701,7 @@
           "v0": {
             "topics": [
               {
-                "symbol": "ESC_CRTD"
+                "symbol": "ESC_CRE"
               }
             ],
             "data": {
@@ -1711,6 +1714,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
                   "i128": {


### PR DESCRIPTION
## Summary

Closes #428

### Changes
- **events.rs**: rename `escrow_created` event symbol from `ESC_CRTD` to `ESC_CRE` as specified in the issue
- **Test snapshots** (7 files): update `ESC_CRTD`→`ESC_CRE` and add the token address field to each `ESC_CRE` event data tuple, making it the correct 5-tuple `(escrow_id, buyer, seller, token, amount)`
- **lib.rs**: add `test_escrow_created_event_includes_token` — asserts the `ESC_CRE` symbol is emitted and the stored escrow record holds the correct token address

Note: issue #446 (which also touched escrow) was already merged.