### PR TITLE
feat(staking): add admin burn_penalties to destroy penalty pool

### DIFF
--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -189,6 +189,33 @@ impl StakingContract {
         Ok(())
     }
 
+    /// Permanently burn accumulated penalty funds (contract balance minus
+    /// active stakes) instead of transferring them out.
+    ///
+    /// This is the irreversible counterpart to [`Self::withdraw_penalties`]:
+    /// it removes the penalty pool from the token's total supply rather than
+    /// sending it to a recipient. The penalty pool is computed identically
+    /// (`contract_balance − total_staked`), so active stakes are never touched.
+    pub fn burn_penalties(env: Env, admin: Address) -> Result<(), Error> {
+        Self::assert_admin(&env, &admin)?;
+
+        let config = Self::load_config(&env)?;
+        let token_client = token::Client::new(&env, &config.staking_token);
+
+        let contract_balance = token_client.balance(&env.current_contract_address());
+        let total_staked: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalStaked)
+            .unwrap_or(0);
+
+        let penalty_balance = contract_balance.saturating_sub(total_staked);
+        if penalty_balance > 0 {
+            token_client.burn(&env.current_contract_address(), &penalty_balance);
+        }
+        Ok(())
+    }
+
     // -----------------------------------------------------------------------
     // User – stake / unstake
     // -----------------------------------------------------------------------

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -28,6 +28,18 @@
 //!
 //! 7. `test_penalty_99_bps_below_floor_is_rejected`
 //!    99 bps (one below the minimum) must be rejected by `set_staking_config`.
+//!
+//! 8. `test_burn_penalties_destroys_penalty_pool`
+//!    After an emergency unstake the admin can call `burn_penalties` to
+//!    permanently destroy the retained penalty pool, dropping both the
+//!    contract balance and the token's total supply by the penalty amount.
+//!
+//! 9. `test_burn_penalties_leaves_active_stakes_untouched`
+//!    `burn_penalties` must only destroy the penalty surplus; tokens backing
+//!    an active stake must remain in the contract.
+//!
+//! 10. `test_burn_penalties_rejects_non_admin`
+//!     Only the configured admin may burn penalties.
 
 #![cfg(test)]
 
@@ -315,5 +327,103 @@ fn test_penalty_99_bps_below_floor_is_rejected() {
     assert!(
         result.is_err(),
         "99 bps is below the 100 bps floor and must be rejected"
+    );
+}
+
+/// After an emergency unstake the retained 1 000-token penalty pool can be
+/// permanently destroyed via `burn_penalties`: the contract balance drops to
+/// zero and the tokens are not credited to anyone (no recipient).
+#[test]
+fn test_burn_penalties_destroys_penalty_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, staker, staking_token, _sac) = setup(&env, 10_000);
+
+    client
+        .stake_tokens(&staker, &String::from_str(&env, "bronze"), &10_000)
+        .unwrap();
+    client.emergency_unstake(&staker).unwrap();
+
+    let token_client = soroban_sdk::token::Client::new(&env, &staking_token);
+
+    // 10 % penalty (1 000) is retained in the contract; staker keeps 9 000.
+    assert_eq!(token_client.balance(client.address()), 1_000);
+    assert_eq!(token_client.balance(&staker), 9_000);
+
+    // Admin burns the penalty pool — no recipient is involved.
+    client.burn_penalties(&admin).unwrap();
+
+    // The penalty is destroyed: contract balance is now zero and the staker's
+    // balance is unchanged (the burned tokens went to no one).
+    assert_eq!(
+        token_client.balance(client.address()),
+        0,
+        "penalty pool must be destroyed after burn"
+    );
+    assert_eq!(
+        token_client.balance(&staker),
+        9_000,
+        "burning penalties must not credit any account"
+    );
+}
+
+/// `burn_penalties` must only destroy the penalty surplus; tokens backing an
+/// active stake must stay inside the contract.
+#[test]
+fn test_burn_penalties_leaves_active_stakes_untouched() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, staker_a, staking_token, sac) = setup(&env, 10_000);
+
+    // A second staker keeps an active stake while the first generates a penalty.
+    let staker_b = Address::generate(&env);
+    sac.mint(&staker_b, &5_000);
+
+    // Staker A emergency-unstakes, retaining a 1 000-token penalty.
+    client
+        .stake_tokens(&staker_a, &String::from_str(&env, "bronze"), &10_000)
+        .unwrap();
+    client.emergency_unstake(&staker_a).unwrap();
+
+    // Staker B stakes 5 000 and leaves it locked.
+    client
+        .stake_tokens(&staker_b, &String::from_str(&env, "bronze"), &5_000)
+        .unwrap();
+
+    let token_client = soroban_sdk::token::Client::new(&env, &staking_token);
+
+    // Contract holds the 1 000 penalty plus B's 5 000 active stake.
+    assert_eq!(token_client.balance(client.address()), 6_000);
+
+    client.burn_penalties(&admin).unwrap();
+
+    // Only the 1 000 penalty is burned; B's 5 000 stake remains.
+    assert_eq!(
+        token_client.balance(client.address()),
+        5_000,
+        "active stake must remain after burning only the penalty surplus"
+    );
+}
+
+/// Only the configured admin may burn penalties.
+#[test]
+fn test_burn_penalties_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, staker, _token, _sac) = setup(&env, 10_000);
+
+    client
+        .stake_tokens(&staker, &String::from_str(&env, "bronze"), &10_000)
+        .unwrap();
+    client.emergency_unstake(&staker).unwrap();
+
+    let intruder = Address::generate(&env);
+    let result = client.try_burn_penalties(&intruder);
+    assert!(
+        result.is_err(),
+        "a non-admin caller must not be able to burn penalties"
     );
 }


### PR DESCRIPTION
Closes #564

## Problem

Emergency-unstake penalties accumulate inside the staking contract. The existing `withdraw_penalties` already lets the admin recover them, but the issue also calls for the ability to **burn** them. Without a burn path, the only way to remove penalties from circulation is to withdraw and manually discard them.

## Change

Adds `burn_penalties(env, admin)` to `contracts/staking/src/lib.rs` as the irreversible counterpart to `withdraw_penalties`:

- Same admin authorization check (`assert_admin`).
- Computes the penalty pool identically to `withdraw_penalties` (`contract_balance − total_staked`), so tokens backing active stakes are never touched.
- Calls `token.burn` from the contract's own address, permanently removing the penalty pool from the token's total supply instead of transferring it to a recipient.

## Tests

Added to `contracts/staking/src/tests.rs`:

- `test_burn_penalties_destroys_penalty_pool` — penalty pool is destroyed; contract balance drops to zero and no account is credited.
- `test_burn_penalties_leaves_active_stakes_untouched` — with a second staker holding an active stake, only the penalty surplus is burned.
- `test_burn_penalties_rejects_non_admin` — non-admin callers are rejected.

## Note

I was unable to run `cargo test -p staking` locally: the workspace currently fails dependency resolution due to a pre-existing conflict in the unrelated `certificates` crate (pins `ed25519-dalek =2.0.0` while `soroban-sdk 22` requires `^2.1.1`). The new code mirrors the already-tested `withdraw_penalties`, with the only new API being the standard token-client `.burn()`. Please confirm CI runs the staking tests.