### PR TITLE
fix(payout-automation): enforce MAX_BATCH_SIZE in execute() — closes #418

### DIFF
--- a/contracts/payout-automation/src/lib.rs
+++ b/contracts/payout-automation/src/lib.rs
@@ -319,4 +319,48 @@ mod test {
         let tc = TokenClient::new(&env, &token_addr);
         assert_eq!(tc.balance(&recipient), 0);
     }
+
+    // Issue #418 — execute with batch exceeding MAX_BATCH_SIZE must be rejected
+    #[test]
+    fn test_execute_batch_too_large_is_rejected() {
+        // Mint enough for 101 payouts of 1 each
+        let (env, admin, token_addr, client) = setup(101);
+        let recipient = Address::generate(&env);
+
+        // Build a batch of MAX_BATCH_SIZE + 1 = 101 entries
+        let mut entries: soroban_sdk::Vec<PayoutEntry> = soroban_sdk::Vec::new(&env);
+        for _ in 0..=MAX_BATCH_SIZE {
+            entries.push_back(PayoutEntry {
+                recipient: recipient.clone(),
+                amount: 1,
+            });
+        }
+
+        let result = client.try_execute(&admin, &token_addr, &entries);
+        assert_eq!(result, Err(Ok(PayoutError::BatchTooLarge)));
+
+        // No funds must have moved
+        let tc = TokenClient::new(&env, &token_addr);
+        assert_eq!(tc.balance(&recipient), 0);
+    }
+
+    // Issue #418 — execute with exactly MAX_BATCH_SIZE entries must succeed
+    #[test]
+    fn test_execute_at_max_batch_size_succeeds() {
+        let (env, admin, token_addr, client) = setup(MAX_BATCH_SIZE as i128);
+        let recipient = Address::generate(&env);
+
+        let mut entries: soroban_sdk::Vec<PayoutEntry> = soroban_sdk::Vec::new(&env);
+        for _ in 0..MAX_BATCH_SIZE {
+            entries.push_back(PayoutEntry {
+                recipient: recipient.clone(),
+                amount: 1,
+            });
+        }
+
+        client.execute(&admin, &token_addr, &entries);
+
+        let tc = TokenClient::new(&env, &token_addr);
+        assert_eq!(tc.balance(&recipient), MAX_BATCH_SIZE as i128);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #418

Issue reported that `execute()` had no upper bound on batch size, which could exhaust Soroban's per-transaction compute budget and DoS the payment system.

## What was already in place

The guard was already implemented in `src/lib.rs`:
- `MAX_BATCH_SIZE: u32 = 100` constant
- `PayoutError::BatchTooLarge` error variant
- Early-return check in `execute()` before any transfers occur

## What this PR adds

Two tests that give the guard formal coverage:

| Test | Verifies |
|---|---|
| `test_execute_batch_too_large_is_rejected` | A batch of 101 entries returns `BatchTooLarge`; no funds move |
| `test_execute_at_max_batch_size_succeeds` | A batch of exactly 100 entries executes successfully |

## Testing

```
cargo test -p payout-automation
```

All existing tests continue to pass alongside the two new ones.

## Security impact

- Prevents unbounded compute consumption in a single transaction
- No funds can be transferred in an oversized batch (fail-fast before the loop)