### PR TITLE
fix(core): emit ADM_CHNG event with old and new admin in transfer_admin

### DIFF
--- a/contracts/chainverse-core/src/test.rs
+++ b/contracts/chainverse-core/src/test.rs
@@ -114,6 +114,22 @@ mod test {
         assert_eq!(config.admin, new_admin);
     }
 
+    #[test]
+    fn test_transfer_admin_emits_adm_chng_event() {
+        let (env, _, client) = setup();
+        let admin = init(&env, &client);
+        let new_admin = Address::generate(&env);
+
+        let events_before = env.events().all().len();
+        client.transfer_admin(&admin, &new_admin);
+        let events_after = env.events().all().len();
+
+        assert!(
+            events_after > events_before,
+            "ADM_CHNG event must be emitted on transfer_admin"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // only_admin guard — unauthorized paths
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #426

The `transfer_admin` function in `chainverse-core` was not emitting an on-chain event, making it impossible for indexers to track admin ownership changes.

## Changes

- **`contracts/chainverse-core/src/lib.rs`** — Added `env.events().publish((symbol_short!("ADM_CHNG"),), (old_admin, new_admin))` call in `transfer_admin` after updating storage.
- **`contracts/chainverse-core/src/test.rs`** — Added `test_transfer_admin_emits_adm_chng_event` to assert that an on-chain event is published when admin is transferred.

## Event Schema

| Field   | Value            |
|---------|-----------------|
| Topics  | `ADM_CHNG`    |
| Data    | `(old_admin: Address, new_admin: Address)` |

## Testing

Added `test_transfer_admin_emits_adm_chng_event` which:
1. Initializes the contract with an admin
2. Records event count before calling `transfer_admin`
3. Asserts the event count increases after the call

> Note: The workspace has a pre-existing dependency conflict (`certificates` pins `ed25519-dalek = "=2.0.0"` while `soroban-sdk 22.0.0` requires `^2.1.1`) that prevents local `cargo test` from running. This conflict exists on `main` as well and is unrelated to this fix.