### PR TITLE
feat(whitelist): fixed the whitelist token

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -47,6 +47,10 @@ impl EscrowContract {
     /// Security requirement: only the configured admin may call this function.
     /// Returns `EscrowError::Unauthorized` if no admin exists or the admin does
     /// not authorize the call.
+    ///
+    /// # Security Note
+    /// This function requires admin authorization to prevent reentrancy or
+    /// infinite-mint attacks from malicious token contracts.
     pub fn whitelist_token(env: Env, token: Address) -> Result<(), EscrowError> {
         storage::require_admin(&env)?;
         storage::whitelist_token(&env, &token);


### PR DESCRIPTION
Closes #554 
Added security documentation to whitelist_token function in the escrow contract to clarify why admin authorization is required. The function already has the proper admin guard implemented via storage::require_admin(), which prevents unauthorized token whitelisting and protects against reentrancy or infinite-mint attacks from malicious token contracts.