### PR TITLE
fix: extend persistent and instance TTL across staking, subscription, certificates, and core contracts

### DIFF
--- a/contracts/certificates/src/lib.rs
+++ b/contracts/certificates/src/lib.rs
@@ -118,11 +118,12 @@ impl CertificateContract {
 
     /// Rejects certificate transfers because certificates are soulbound.
     pub fn transfer(
-        _env: Env,
+        env: Env,
         _from: Address,
         _to: Address,
         _course_id: u64,
     ) -> Result<(), ContractError> {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         Err(ContractError::SoulboundTransferNotAllowed)
     }
 

--- a/contracts/chainverse-core/src/lib.rs
+++ b/contracts/chainverse-core/src/lib.rs
@@ -168,6 +168,9 @@ impl ChainverseCore {
         config.admin = new_admin.clone();
 
         env.storage().persistent().set(&DataKey::Config, &config);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Config, MIN_TTL, MAX_TTL);
         analytics::record(&env, EVT_ADMIN_CHANGED);
         env.events()
             .publish((symbol_short!("ADM_CHNG"),), (old_admin, new_admin));

--- a/contracts/escrow/staking.rs
+++ b/contracts/escrow/staking.rs
@@ -28,8 +28,8 @@ pub enum StakingDataKey {
 // TTL constants (in ledgers; Stellar produces ~1 ledger / 5 s)
 // ---------------------------------------------------------------------------
 
-/// Keep stake records for ~30 days.
-const STAKE_TTL_LEDGERS: u32 = 518_400;
+const MIN_TTL: u32 = 17_280; // ~1 day
+const MAX_TTL: u32 = 518_400; // ~30 days
 
 // ---------------------------------------------------------------------------
 // Module
@@ -106,8 +106,8 @@ impl StakingModule {
             .set(&StakingDataKey::Tier(tier.id.clone()), &tier);
         env.storage().persistent().extend_ttl(
             &StakingDataKey::Tier(tier.id.clone()),
-            STAKE_TTL_LEDGERS,
-            STAKE_TTL_LEDGERS,
+            MIN_TTL,
+            MAX_TTL,
         );
 
         // Append tier ID to the tier list.
@@ -450,8 +450,8 @@ impl StakingModule {
             .set(&StakingDataKey::Stake(staker.clone()), stake);
         env.storage().persistent().extend_ttl(
             &StakingDataKey::Stake(staker.clone()),
-            STAKE_TTL_LEDGERS,
-            STAKE_TTL_LEDGERS,
+            MIN_TTL,
+            MAX_TTL,
         );
     }
 

--- a/contracts/escrow/subscription.rs
+++ b/contracts/escrow/subscription.rs
@@ -481,6 +481,7 @@ impl SubscriptionContract {
         subscription.status = MembershipStatus::Inactive;
         subscription.paused_at = None;
         env.storage().persistent().set(&key, &subscription);
+        env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL);
 
         // Emit subscription cancelled event
         env.events().publish(
@@ -772,6 +773,7 @@ impl SubscriptionContract {
 
         // Store updated tier
         env.storage().persistent().set(&key, &tier);
+        env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL);
 
         // Emit tier updated event
         env.events().publish(
@@ -839,6 +841,7 @@ impl SubscriptionContract {
         tier.updated_at = env.ledger().timestamp();
 
         env.storage().persistent().set(&key, &tier);
+        env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL);
 
         // Emit tier deactivated event
         env.events().publish(


### PR DESCRIPTION
## Summary

This PR resolves four storage TTL issues across the codebase. Ledger entries in Soroban expire if their TTL is never extended — these fixes ensure that every write to persistent or instance storage is paired with a corresponding `extend_ttl` call, preventing contract data from being silently dropped on testnet and mainnet.

---

### #517 — `staking.rs`: fix extend_ttl constants for staking tier records

**Problem:** `create_staking_tier` and `save_stake` both called `extend_ttl` with `STAKE_TTL_LEDGERS` for *both* the threshold and target arguments (518,400 / 518,400). There was no `MIN_TTL` constant, so the TTL was never extended unless it had already dropped to exactly 0.

**Fix:**
- Replaced `STAKE_TTL_LEDGERS` with two named constants: `MIN_TTL = 17_280` (~1 day) and `MAX_TTL = 518_400` (~30 days).
- Both `extend_ttl` calls now use `MIN_TTL, MAX_TTL` so the record is refreshed whenever its remaining TTL falls below one day.

---

### #514 — `chainverse-core/lib.rs`: extend Config TTL in `transfer_admin`

**Problem:** `initialize` and `update_config` both called `extend_ttl` after writing `DataKey::Config`, but `transfer_admin` wrote the same key and skipped the TTL refresh. A busy contract transferring admin rights could inadvertently shorten the Config entry's remaining lifetime.

**Fix:** Added `extend_ttl(&DataKey::Config, MIN_TTL, MAX_TTL)` immediately after the `persistent().set` in `transfer_admin`, consistent with the other two write paths.

---

### #516 — `subscription.rs`: add missing extend_ttl to cancel, update_tier, deactivate_tier

**Problem:** Three functions mutated persistent records without refreshing their TTL:
- `cancel_subscription` — wrote the updated subscription record.
- `update_tier` — wrote the mutated tier record.
- `deactivate_tier` — wrote the deactivated tier record.

**Fix:** Added `extend_ttl(&key, MIN_TTL, MAX_TTL)` after each `persistent().set` call in those three functions, matching the pattern already established in `create_subscription`, `pause_subscription`, `resume_subscription`, `renew_subscription`, and `create_tier`.

---

### #513 — `certificates/lib.rs`: add instance TTL bump to `transfer`

**Problem:** Every `#[contractimpl]` function bumped the instance TTL via `env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL)` except `transfer`, which used `_env` (unused parameter) and therefore could not call the bump. The contract's instance storage could expire if `transfer` was the most recently invoked function.

**Fix:** Renamed `_env` to `env` and added the instance TTL bump as the first statement in `transfer`, consistent with every other public function in the contract.

---

Closes #513
Closes #514
Closes #516
Closes #517