### PR TITLE
fix(storage): move/extend persistent TTL for vault, royalty, reward, and payout-auth records

### DIFF
--- a/contracts/escrow-vault/src/lib.rs
+++ b/contracts/escrow-vault/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+const VAULT_MIN_TTL: u32 = 100_000;
+const VAULT_MAX_TTL: u32 = 500_000;
+
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, Vec};
 
 // ---------------------------------------------------------------------------
@@ -106,6 +109,9 @@ impl EscrowVault {
             status: VaultStatus::Pending,
         };
         env.storage().persistent().set(&DataKey::Vault(id), &vault);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Vault(id), VAULT_MIN_TTL, VAULT_MAX_TTL);
 
         // Pull funds from depositor into the contract
         soroban_sdk::token::Client::new(&env, &token).transfer(
@@ -157,6 +163,9 @@ impl EscrowVault {
         env.storage()
             .persistent()
             .set(&DataKey::Vault(vault_id), &vault);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Vault(vault_id), VAULT_MIN_TTL, VAULT_MAX_TTL);
         Ok(())
     }
 
@@ -193,6 +202,9 @@ impl EscrowVault {
         env.storage()
             .persistent()
             .set(&DataKey::Vault(vault_id), &vault);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Vault(vault_id), VAULT_MIN_TTL, VAULT_MAX_TTL);
 
         env.events().publish(
             (soroban_sdk::symbol_short!("cancelled"), vault_id),


### PR DESCRIPTION
## Summary

This PR resolves four storage-related issues where contract data was either stored in `instance()` storage (which is wiped on upgrade) or stored in `persistent()` storage without a TTL extension (which causes ledger eviction).

---

### #519 — `escrow-vault/lib.rs`: extend TTL on every vault persistent write

**Problem:** Vault records were written to `persistent()` storage but never had their TTL extended. A long-lived vault holding funds could be evicted from the ledger before it is settled, permanently destroying the record.

**Fix:** Added `VAULT_MIN_TTL = 100_000` and `VAULT_MAX_TTL = 500_000` constants and called `extend_ttl` after every `persistent().set()` for vault records:
- `create_vault` — TTL extended immediately after the vault is stored
- `approve_release` — TTL refreshed each time an approval is recorded or the vault is released
- `cancel_vault` — TTL refreshed on cancellation so the audit record survives

---

### #520 — `payout-automation/lib.rs`: authorised-callers list in persistent storage

**Problem:** The authorised-callers list was in `instance()` storage. A contract upgrade would wipe all authorised callers, permanently locking the contract.

**Status:** Already resolved by a prior commit (`fix: resolve issues #367, #372, #374, #376`). Every `DataKey::Authorised` write uses `persistent().set()` + `extend_ttl` with `AUTH_MIN_TTL`/`AUTH_MAX_TTL`. Confirmed correct in current codebase.

---

### #518 — `royalty.rs`: extend TTL for royalty config in persistent storage

**Problem:** Royalty configurations were saved to `persistent()` with no TTL extension, risking eviction and permanent loss of royalty data.

**Status:** Already resolved by a prior commit. `set_royalty` calls `persistent().extend_ttl(&DataKey::Royalty(token_id), MIN_TTL, MAX_TTL)` immediately after every save. Confirmed correct in current codebase.

---

### #515 — `reward/src/storage.rs`: rewarded-user flag in persistent storage

**Problem:** The `REWARDED` flag per user was in `instance()` storage. On contract upgrade, instance storage is reset — all users could claim rewards again, draining the treasury.

**Status:** Already resolved by a prior commit (`fix(reward): persist rewarded flag across upgrades and extend TTL`). `set_rewarded` uses `persistent().set()` + `extend_ttl` with `MIN_TTL = 6_307_200` (~1 year) and `MAX_TTL = 12_614_400` (~2 years). Confirmed correct in current codebase.

---

## Files changed

| File | Change |
|------|--------|
| `contracts/escrow-vault/src/lib.rs` | Added TTL constants + `extend_ttl` in `create_vault`, `approve_release`, `cancel_vault` |

Closes #515
Closes #518
Closes #519
Closes #520