### PR TITLE
feat(testnet): add deployment scripts, persistent token storage, and testnet account setup

### DIFF
--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -3,6 +3,8 @@ set -e
 
 NETWORK="testnet"
 SOURCE="deployer"
+RPC_URL="https://soroban-testnet.stellar.org"
+PASSPHRASE="Test SDF Network ; September 2015"
 WASM_DIR="contracts/target/wasm32-unknown-unknown/release"
 OUTPUT_DIR="deployments"
 OUTPUT_FILE="$OUTPUT_DIR/testnet.json"
@@ -24,6 +26,8 @@ mkdir -p "$OUTPUT_DIR"
 # Start JSON output
 echo "{" > "$OUTPUT_FILE"
 echo "  \"network\": \"$NETWORK\"," >> "$OUTPUT_FILE"
+echo "  \"rpc_url\": \"$RPC_URL\"," >> "$OUTPUT_FILE"
+echo "  \"passphrase\": \"$PASSPHRASE\"," >> "$OUTPUT_FILE"
 echo "  \"deployed_at\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"," >> "$OUTPUT_FILE"
 echo "  \"contracts\": {" >> "$OUTPUT_FILE"
 


### PR DESCRIPTION
## Summary

This PR closes four open issues related to testnet tooling and token contract storage safety.

### #523 — `scripts/build-all.sh`
- Compiles all Soroban contracts to WASM with a single command (`cargo build --workspace --release --target wasm32-unknown-unknown`)
- Lists produced `.wasm` artifacts after a successful build
- Eliminates the need for contributors to know every individual contract path

### #522 — `scripts/setup-testnet-account.sh`
- Generates a `deployer` keypair via `stellar keys generate`
- Resolves the public key and funds it via the Stellar Friendbot endpoint
- Removes the manual step of visiting Friendbot in a browser

### #524 — `scripts/deploy-testnet.sh`
- Iterates all compiled WASMs under `contracts/target/wasm32-unknown-unknown/release`
- Calls `stellar contract deploy` for each WASM using the `deployer` account
- Writes a complete `deployments/testnet.json` including `network`, `rpc_url`, `passphrase`, `deployed_at`, and a `contracts` map — now consistent with the existing template structure

### #521 — `contracts/chv_token/src/lib.rs`
- Moved all `DataKey::Balance(Address)` reads and writes from `instance()` to `env.storage().persistent()`
- Added `extend_ttl` on every balance write (`BALANCE_MIN_TTL = 100_000`, `BALANCE_MAX_TTL = 200_000`)
- Prevents storage overflow with many token holders (instance storage has a fixed size cap)

## Closes

Closes #521
Closes #522
Closes #523
Closes #524

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)