### PR TITLE
fix: escrow TTL extension, subscription token transfer, and certifica…

### DIFF
--- a/contracts/certificates/src/storage.rs
+++ b/contracts/certificates/src/storage.rs
@@ -55,9 +55,12 @@ pub fn has_certificate(env: &Env, wallet: &Address, course_id: u64) -> bool {
 }
 
 pub fn load_certificate(env: &Env, wallet: &Address, course_id: u64) -> Option<Certificate> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Certificate(wallet.clone(), course_id))
+    let key = DataKey::Certificate(wallet.clone(), course_id);
+    let cert = env.storage().persistent().get(&key);
+    if cert.is_some() {
+        env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL);
+    }
+    cert
 }
 
 // ~1 year expressed in ledger entries (5-second close time)

--- a/contracts/chainverse-core/src/escrow/mod.rs
+++ b/contracts/chainverse-core/src/escrow/mod.rs
@@ -2,6 +2,9 @@ use soroban_sdk::{contracttype, token::Client as TokenClient, Address, Env, Vec}
 
 use crate::errors::ContractError;
 
+const MIN_TTL: u32 = 4_096;
+const MAX_TTL: u32 = 100_000;
+
 pub mod active_query;
 pub mod id_generator;
 pub mod pagination;
@@ -66,9 +69,9 @@ fn load(env: &Env, id: u64) -> Result<EscrowRecord, ContractError> {
 }
 
 fn save(env: &Env, record: &EscrowRecord) {
-    env.storage()
-        .persistent()
-        .set(&EscrowKey::Record(record.id), record);
+    let key = EscrowKey::Record(record.id);
+    env.storage().persistent().set(&key, record);
+    env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL);
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/escrow/subscription.rs
+++ b/contracts/escrow/subscription.rs
@@ -896,6 +896,9 @@ impl SubscriptionContract {
         // Validate payment
         Self::validate_payment(&env, &payment_token, final_price, &user)?;
 
+        let token_client = token::Client::new(&env, &payment_token);
+        token_client.transfer(&user, &env.current_contract_address(), &final_price);
+
         // Calculate duration based on billing cycle
         let duration = match billing_cycle {
             BillingCycle::Monthly => 30 * 24 * 60 * 60, // 30 days in seconds


### PR DESCRIPTION
 ## Summary

   - **#499 / #500 — chainverse-core escrow**: Added `extend_ttl` to the `save` helper so
   every escrow record (including ones just marked Cancelled or Expired) has its ledger TTL
   refreshed and is not silently dropped.
   - **#504 — subscription `create_subscription_with_tier`**: Wired the missing
   `token_client.transfer` call after payment validation — tokens were validated but never
   actually collected at subscription creation.
   - **#512 — certificates `load_certificate`**: Added `extend_ttl` on read so an active
   certificate's TTL is bumped every time it is accessed, preventing expiry while it is still
   in use.

   ## Test plan

   - [ ] Deploy chainverse-core to testnet, create an escrow, cancel/refund it, confirm the
   record persists past the next ledger close
   - [ ] Call `create_subscription_with_tier` and verify the token balance is debited from the
   user
   - [ ] Mint a certificate, call `get_certificate` repeatedly near the TTL boundary, confirm
   it does not expire

Closes #499
Closes #500
Closes #504
Closes #512
