### PR TITLE
ci: cache Stellar CLI install in CI workflow (#530)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,23 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Add wasm target
-        run: rustup target add wasm32-unknown-unknown
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-      - name: Cargo audit
-        working-directory: contracts
-        run: cargo audit
-
-      - name: Security audit
-        working-directory: contracts
-        run: cargo audit
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -42,10 +29,15 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('contracts/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
+      - name: Cache Stellar CLI binary
+        id: cache-stellar-cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/stellar
+          key: ${{ runner.os }}-stellar-cli-${{ hashFiles('contracts/Cargo.lock') }}
 
       - name: Install Stellar CLI
+        if: steps.cache-stellar-cli.outputs.cache-hit != 'true'
         run: cargo install --locked stellar-cli --features opt
 
       - name: Set up Stellar CLI identity
@@ -58,15 +50,20 @@ jobs:
           fi
           stellar keys generate ci --secret-key "$STELLAR_SECRET_KEY"
 
-      - name: Security audit
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Cargo audit
         working-directory: contracts
         run: cargo audit
 
       - name: Format check
         run: cargo fmt --all -- --check
+
       - name: Build all contracts
         working-directory: contracts
         run: cargo build --target wasm32-unknown-unknown --release
+
       - name: WASM size check
         working-directory: contracts
         run: |


### PR DESCRIPTION
## Summary
Adds a cached install step for Stellar CLI so it is only compiled from source when the binary is not already cached.

## Changes
- Added `Cache Stellar CLI binary` step keyed on `Cargo.lock` hash
- Guarded `cargo install --locked stellar-cli --features opt` behind `cache-hit != 'true'`
- Removed duplicated `cargo-audit` and `security audit` steps from the original workflow

Closes #530