### PR TITLE
docs: comprehensive DEPLOYMENT.md for testnet deploy process (#533)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,55 +1,152 @@
-# Deployment Guide
+# ChainVerse Testnet Deployment Guide
 
 ## Prerequisites
 
-Before the CI deploy workflow can run, repo admins must add the following secrets under **Settings → Secrets and variables → Actions**.
+- **Rust** with the `wasm32-unknown-unknown` target:
+  ```bash
+  rustup target add wasm32-unknown-unknown
+  ```
+- **Stellar CLI** installed:
+  ```bash
+  cargo install --locked stellar-cli --features opt
+  ```
+- A **funded testnet account** (see [Account Setup](#account-setup) below).
 
-### Required GitHub Secrets
+## Account Setup
 
-| Secret | Value |
+Generate a deployer keypair and fund it via Friendbot:
+
+```bash
+./scripts/setup-testnet-account.sh
+```
+
+Or manually:
+
+```bash
+stellar keys generate deployer --network testnet
+PUBKEY=$(stellar keys address deployer)
+curl -s "https://friendbot.stellar.org?addr=$PUBKEY"
+```
+
+Keep the secret key from `stellar keys show deployer` — you will need it as `STELLAR_SECRET_KEY`.
+
+## Environment Variable Setup
+
+| Variable | Description |
 |---|---|
-| `STELLAR_SECRET_KEY` | Testnet deployer secret key (funded via Friendbot) |
+| `STELLAR_SECRET_KEY` | Secret key of the funded deployer account |
 | `STELLAR_NETWORK` | `testnet` |
 | `STELLAR_RPC_URL` | `https://soroban-testnet.stellar.org` |
 
-### Generating and Funding a Deployer Account
-
-1. Generate a new keypair:
-   ```bash
-   stellar keys generate deployer --network testnet
-   stellar keys address deployer      # copy the public key
-   stellar keys show deployer         # copy the secret key → use as STELLAR_SECRET_KEY
-   ```
-
-2. Fund the account via Friendbot:
-   ```bash
-   curl "https://friendbot.stellar.org?addr=<PUBLIC_KEY>"
-   ```
-
-   Or run the helper script:
-   ```bash
-   ./scripts/setup-testnet-account.sh
-   ```
-
-### Adding Secrets to GitHub
-
-1. Go to your repository on GitHub.
-2. Navigate to **Settings → Secrets and variables → Actions**.
-3. Click **New repository secret** for each of the three secrets above.
-
-## Deploy Workflow
-
-Once secrets are configured, build and deploy all contracts to testnet:
+Export them locally before running scripts:
 
 ```bash
-# Build all contracts
-./scripts/build-all.sh
-
-# Deploy to testnet (writes addresses to deployments/testnet.json)
-./scripts/deploy-testnet.sh
+export STELLAR_SECRET_KEY=<your-secret-key>
+export STELLAR_NETWORK=testnet
+export STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 ```
 
-Deployed contract addresses are recorded in `deployments/testnet.json` and can be referenced by the frontend and backend.
+## Manual Deploy Process
+
+1. **Top up the deployer account** (pre-flight Friendbot call):
+   ```bash
+   ./scripts/fund-testnet.sh
+   ```
+
+2. **Build all contracts** to WASM:
+   ```bash
+   ./scripts/build-all.sh
+   ```
+
+3. **Deploy all contracts** to testnet:
+   ```bash
+   ./scripts/deploy-testnet.sh
+   ```
+
+   Contract addresses are written to `deployments/testnet.json`.
+
+## Automated CI Deploy Process
+
+The GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push to `main`. It:
+
+1. Installs Rust and the Stellar CLI (cached between runs).
+2. Sets up the `deployer` identity from the `STELLAR_SECRET_KEY` repository secret.
+3. Builds all contracts.
+4. Runs `cargo test`.
+
+To trigger a deploy from CI, ensure the following repository secrets are set under **Settings → Secrets and variables → Actions**:
+
+| Secret | Value |
+|---|---|
+| `STELLAR_SECRET_KEY` | Testnet deployer secret key |
+| `STELLAR_NETWORK` | `testnet` |
+| `STELLAR_RPC_URL` | `https://soroban-testnet.stellar.org` |
+
+## Verifying Deployment
+
+After deploying, call `version()` on each contract to confirm it is live:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ADDRESS> \
+  --network testnet \
+  -- version
+```
+
+Expected output: `1` (incremented on each breaking change).
+
+You can also run the smoke-test script once it is in place:
+
+```bash
+./scripts/smoke-test.sh
+```
+
+## Reading Contract Addresses
+
+Deployed addresses are stored in `deployments/testnet.json`:
+
+```json
+{
+  "network": "testnet",
+  "deployed_at": "2024-01-01T00:00:00Z",
+  "contracts": {
+    "escrow": "C...",
+    "escrow_vault": "C...",
+    "certificates": "C...",
+    "chainverse_core": "C...",
+    "reward": "C...",
+    "chv_token": "C...",
+    "course_registry": "C...",
+    "payout_automation": "C..."
+  }
+}
+```
+
+Read a specific address:
+
+```bash
+jq -r '.contracts.escrow' deployments/testnet.json
+```
+
+## Resetting Testnet State
+
+Testnet state is ephemeral — accounts and contracts can expire. To reset:
+
+1. Re-fund the deployer:
+   ```bash
+   PUBKEY=$(stellar keys address deployer --network testnet)
+   curl -s "https://friendbot.stellar.org?addr=$PUBKEY"
+   ```
+
+2. Re-deploy all contracts:
+   ```bash
+   ./scripts/build-all.sh
+   ./scripts/deploy-testnet.sh
+   ```
+
+   `deployments/testnet.json` will be overwritten with the new addresses.
+
+3. Update any frontend or backend configuration that references the old contract addresses.
 
 ## Network Details
 


### PR DESCRIPTION
## Summary
Rewrites `DEPLOYMENT.md` with a full guide for deploying ChainVerse contracts to testnet.

## Sections added
- Prerequisites (Rust, Stellar CLI, funded account)
- Account setup via `setup-testnet-account.sh` or manual Friendbot
- Environment variable reference table
- Step-by-step manual deploy process
- Automated CI deploy process and required secrets
- Post-deploy verification via `version()` and smoke-test
- Reading contract addresses from `deployments/testnet.json`
- Resetting testnet state

Closes #533