### PR TITLE
feat: add version() to each contract for post-deploy verification (#534)

### DIFF
--- a/contracts/certificates/src/lib.rs
+++ b/contracts/certificates/src/lib.rs
@@ -138,4 +138,9 @@ impl CertificateContract {
         env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
     }
+
+    /// Returns the contract version for post-deploy verification.
+    pub fn version(_env: Env) -> u32 {
+        1
+    }
 }

--- a/contracts/escrow-vault/src/lib.rs
+++ b/contracts/escrow-vault/src/lib.rs
@@ -248,6 +248,11 @@ impl EscrowVault {
         env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
     }
+
+    /// Returns the contract version for post-deploy verification.
+    pub fn version(_env: Env) -> u32 {
+        1
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/payout-automation/src/lib.rs
+++ b/contracts/payout-automation/src/lib.rs
@@ -159,6 +159,11 @@ impl PayoutAutomation {
         }
         Ok(())
     }
+
+    /// Returns the contract version for post-deploy verification.
+    pub fn version(_env: Env) -> u32 {
+        1
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/reward/src/lib.rs
+++ b/contracts/reward/src/lib.rs
@@ -115,4 +115,9 @@ impl RewardContract {
             .publish((soroban_sdk::symbol_short!("UNPAUSED"),), (caller,));
         Ok(())
     }
+
+    /// Returns the contract version for post-deploy verification.
+    pub fn version(_env: Env) -> u32 {
+        1
+    }
 }

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -365,6 +365,11 @@ impl StakingContract {
         Ok(())
     }
 
+    /// Returns the contract version for post-deploy verification.
+    pub fn version(_env: Env) -> u32 {
+        1
+    }
+
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds `pub fn version(_env: Env) -> u32 { 1 }` to the `#[contractimpl]` block of every contract that was missing it.

## Contracts updated
- `contracts/certificates/src/lib.rs`
- `contracts/escrow-vault/src/lib.rs`
- `contracts/payout-automation/src/lib.rs`
- `contracts/staking/src/lib.rs`
- `contracts/reward/src/lib.rs`

Contracts that already had a `version()` function (`escrow`, `chainverse-core`, `chv_token`, `course_registry`) were left unchanged.

## Usage
After deploying, call `version()` on each contract to confirm it is live:
```bash
stellar contract invoke --id <CONTRACT_ADDRESS> --network testnet -- version
```
Increment the return value on each breaking change.

Closes #534