### PR TITLE
feat: add Friendbot pre-flight to fund deployer before deployment (#536)

### DIFF
--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -9,6 +9,11 @@ WASM_DIR="contracts/target/wasm32-unknown-unknown/release"
 OUTPUT_DIR="deployments"
 OUTPUT_FILE="$OUTPUT_DIR/testnet.json"
 
+# Pre-flight: top up deployer account via Friendbot
+PUBKEY=$(stellar keys address deployer --network testnet)
+curl -s "https://friendbot.stellar.org?addr=$PUBKEY" > /dev/null
+echo "Account balance topped up"
+
 # Ensure WASMs exist
 if [ ! -d "$WASM_DIR" ]; then
   echo "No WASM build found. Run ./scripts/build-all.sh first."

--- a/scripts/fund-testnet.sh
+++ b/scripts/fund-testnet.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-DEPLOYER_ACCOUNT="${DEPLOYER_ACCOUNT:-}"
-FUND_AMOUNT="${FUND_AMOUNT:-1000}"
-
-if [[ -z "$DEPLOYER_ACCOUNT" ]]; then
-  echo "error: DEPLOYER_ACCOUNT is required" >&2
-  exit 2
-fi
-
-if ! command -v stellar >/dev/null 2>&1; then
-  echo "error: stellar CLI is required" >&2
-  exit 127
-fi
-
-stellar keys fund "$DEPLOYER_ACCOUNT" --network testnet --amount "$FUND_AMOUNT"
-echo "funded $DEPLOYER_ACCOUNT with $FUND_AMOUNT testnet lumens"
+PUBKEY=$(stellar keys address deployer --network testnet)
+curl -s "https://friendbot.stellar.org?addr=$PUBKEY" > /dev/null
+echo "Account balance topped up"


### PR DESCRIPTION
## Summary
Prevents deployment failures caused by insufficient testnet account balance by automatically topping up the deployer via Friendbot before each deploy.

## Changes
- **`scripts/fund-testnet.sh`**: Rewritten to call Friendbot using `stellar keys address deployer` (no external env var required)
- **`scripts/deploy-testnet.sh`**: Added Friendbot pre-flight at the start of the script

## Usage
```bash
# Standalone top-up
./scripts/fund-testnet.sh

# Automatically called at the start of every deploy
./scripts/deploy-testnet.sh
```

Closes #536