### PR TITLE
fix: pull depositor tokens into contract on escrow creation

### DIFF
--- a/contracts/chainverse-core/src/escrow/mod.rs
+++ b/contracts/chainverse-core/src/escrow/mod.rs
@@ -78,9 +78,6 @@ fn save(env: &Env, record: &EscrowRecord) {
 /// Creates a new escrow and returns its id.
 /// The depositor must authorise this call.
 /// `expires_at` is a Unix timestamp; pass 0 for no expiry.
-///
-/// Note: No token transfer occurs in this function. The escrow ID is assigned and the record is saved here.
-/// The actual token transfer to the contract happens in `release`, ensuring that if a transfer fails, no ID is consumed without a record.
 pub fn create(
     env: &Env,
     depositor: Address,
@@ -92,6 +89,8 @@ pub fn create(
     depositor.require_auth();
     crate::utils::validate_amount(amount)?;
     crate::utils::require_supported_token(env, &token)?;
+
+    TokenClient::new(env, &token).transfer(&depositor, &env.current_contract_address(), &amount);
 
     let id = next_id(env);
     let record = EscrowRecord {


### PR DESCRIPTION
## Summary

- **#497** — `create_escrow` in `chainverse-core/escrow/mod.rs` was saving the escrow record without transferring tokens from the depositor, leaving escrows unbacked. Added `TokenClient::transfer` to pull funds into the contract at creation time and removed the misleading doc comment that claimed the transfer happened in `release`.
- **#498** — `release_escrow` already emits a `TokenClient::transfer` to the recipient; confirmed correct.
- **#506** — `cancel_vault` in `escrow-vault/lib.rs` is already implemented with depositor auth check, pending-status guard, token refund, and cancelled-status update; confirmed correct.
- **#507** — `mint` in `certificates/lib.rs` already reads `backend_public_key` from storage rather than accepting it as a caller parameter; confirmed correct.

## Test plan

- [ ] Deploy `chainverse-core` and call `create_escrow` — verify the contract's token balance increases by `amount`
- [ ] Call `release_escrow` — verify recipient's balance increases and contract balance reaches zero
- [ ] Call `cancel_vault` on a pending vault — verify depositor receives refund and status flips to `Cancelled`
- [ ] Attempt to mint a certificate with a self-supplied public key — verify the call is rejected

Closes #497
Closes #498
Closes #506
Closes #507