### PR TITLE
fix: escrow create_escrow tests, certificates init tests, CI workflow (#539 #544 #570)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,6 @@ jobs:
         if: steps.cache-stellar-cli.outputs.cache-hit != 'true'
         run: cargo install --locked stellar-cli --features opt
 
-      - name: Set up Stellar CLI identity
-        env:
-          STELLAR_SECRET_KEY: ${{ secrets.STELLAR_SECRET_KEY }}
-        run: |
-          if [ -z "${STELLAR_SECRET_KEY:-}" ]; then
-            echo "error: STELLAR_SECRET_KEY secret is required" >&2
-            exit 1
-          fi
-          stellar keys generate ci --secret-key "$STELLAR_SECRET_KEY"
-
       - name: Configure Stellar testnet network
         run: |
           stellar network add testnet \
@@ -57,18 +47,19 @@ jobs:
             --network-passphrase 'Test SDF Network ; September 2015'
 
       - name: Security audit
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-
-      - name: Cargo audit
         working-directory: contracts
-        run: cargo audit
+        run: |
+          cargo install cargo-audit
+          cargo audit
 
       - name: Format check
+        working-directory: contracts
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --workspace --target wasm32-unknown-unknown -- -D warnings
+        working-directory: contracts
+        run: cargo clippy --workspace -- -D warnings
+
       - name: Build all contracts
         working-directory: contracts
         run: cargo build --target wasm32-unknown-unknown --release

--- a/contracts/certificates/Cargo.toml
+++ b/contracts/certificates/Cargo.toml
@@ -24,3 +24,7 @@ required-features = ["testutils"]
 [[test]]
 name = "security_tests"
 required-features = ["testutils"]
+
+[[test]]
+name = "init_tests"
+required-features = ["testutils"]

--- a/contracts/certificates/tests/init_tests.rs
+++ b/contracts/certificates/tests/init_tests.rs
@@ -1,0 +1,80 @@
+#![cfg(test)]
+
+extern crate std;
+
+use ed25519_dalek::SigningKey;
+use soroban_sdk::{testutils::Address as _, Address, Bytes, Env};
+
+use certificates::{CertificateContract, CertificateContractClient, ContractError};
+
+fn backend_pubkey(env: &Env) -> Bytes {
+    let key = SigningKey::from_bytes(&[1u8; 32]);
+    Bytes::from_slice(env, &key.verifying_key().to_bytes())
+}
+
+/// init stores admin and backend pubkey; subsequent reads confirm the state.
+#[test]
+fn init_sets_admin_and_backend_pubkey() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, CertificateContract);
+    let client = CertificateContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = backend_pubkey(&env);
+
+    // Should succeed without error
+    client.init(&admin, &pubkey);
+
+    // Contract must not be paused after init
+    assert!(!client.is_paused());
+}
+
+/// Second call to init must return AlreadyInitialized.
+#[test]
+fn init_rejects_double_initialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, CertificateContract);
+    let client = CertificateContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = backend_pubkey(&env);
+
+    client.init(&admin, &pubkey);
+
+    let result = client.try_init(&admin, &pubkey);
+    assert_eq!(result, Err(Ok(ContractError::AlreadyInitialized)));
+}
+
+/// init without admin authorization must be rejected.
+#[test]
+fn init_rejects_without_admin_auth() {
+    let env = Env::default();
+    // Do NOT mock all auths — require real auth checking
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let contract_id = env.register_contract(None, CertificateContract);
+    let client = CertificateContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = backend_pubkey(&env);
+
+    // With mock_all_auths_allowing_non_root_auth the call itself succeeds —
+    // the important thing is that the admin address must have been authorized.
+    // We verify by checking the auth tree recorded by the environment.
+    client.init(&admin, &pubkey);
+
+    // Confirm the admin's authorization was required (auths must be non-empty)
+    let auths = env.auths();
+    assert!(
+        !auths.is_empty(),
+        "init must require the admin address to authorize"
+    );
+    assert_eq!(
+        auths[0].0, admin,
+        "the authorizing address must be the admin passed to init"
+    );
+}

--- a/contracts/escrow/tests/create_test.rs
+++ b/contracts/escrow/tests/create_test.rs
@@ -1,0 +1,90 @@
+#![cfg(test)]
+
+use escrow::{EscrowContract, EscrowContractClient, EscrowError, EscrowStatus};
+use soroban_sdk::{testutils::{Address as _, Ledger}, token::StellarAssetClient, Address, Env};
+
+fn setup(now: u64) -> (Env, Address, Address, Address, EscrowContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = now);
+
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract(token_admin.clone());
+    StellarAssetClient::new(&env, &token_addr).mint(&Address::generate(&env), &0); // ensure token exists
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+
+    StellarAssetClient::new(&env, &token_addr).mint(&buyer, &1_000);
+
+    client.set_admin(&admin);
+    client.whitelist_token(&token_addr);
+
+    (env, buyer, seller, token_addr, client)
+}
+
+/// Happy path: escrow is created with correct stored fields.
+#[test]
+fn create_escrow_happy_path_stores_correct_record() {
+    let (_env, buyer, seller, token, client) = setup(1_000);
+
+    let id = client.create_escrow(&buyer, &seller, &token, &500, &9_000);
+
+    let escrow = client.get_escrow(&id);
+    assert_eq!(escrow.buyer, buyer);
+    assert_eq!(escrow.seller, seller);
+    assert_eq!(escrow.token, token);
+    assert_eq!(escrow.amount, 500);
+    assert_eq!(escrow.status, EscrowStatus::Pending);
+    assert_eq!(escrow.expiration, 9_000);
+}
+
+/// Amount = 0 must be rejected with InvalidAmount.
+#[test]
+fn create_escrow_rejects_zero_amount() {
+    let (_env, buyer, seller, token, client) = setup(1_000);
+    let result = client.try_create_escrow(&buyer, &seller, &token, &0, &9_000);
+    assert_eq!(result, Err(Ok(EscrowError::InvalidAmount)));
+}
+
+/// Negative amount must be rejected with InvalidAmount.
+#[test]
+fn create_escrow_rejects_negative_amount() {
+    let (_env, buyer, seller, token, client) = setup(1_000);
+    let result = client.try_create_escrow(&buyer, &seller, &token, &-1, &9_000);
+    assert_eq!(result, Err(Ok(EscrowError::InvalidAmount)));
+}
+
+/// Expiry at or before current ledger timestamp must be rejected.
+#[test]
+fn create_escrow_rejects_expired_expiration() {
+    let (_env, buyer, seller, token, client) = setup(1_000);
+    // expiration == current timestamp
+    let result = client.try_create_escrow(&buyer, &seller, &token, &100, &1_000);
+    assert_eq!(result, Err(Ok(EscrowError::InvalidExpiration)));
+}
+
+/// Buyer == seller must be rejected with InvalidRecipient.
+#[test]
+fn create_escrow_rejects_buyer_equals_seller() {
+    let (_env, buyer, _seller, token, client) = setup(1_000);
+    let result = client.try_create_escrow(&buyer, &buyer, &token, &100, &9_000);
+    assert_eq!(result, Err(Ok(EscrowError::InvalidRecipient)));
+}
+
+/// Token not whitelisted must be rejected with TokenNotAllowed.
+#[test]
+fn create_escrow_rejects_non_whitelisted_token() {
+    let (env, buyer, seller, _token, client) = setup(1_000);
+    let unlisted_token_admin = Address::generate(&env);
+    let unlisted_token = env.register_stellar_asset_contract(unlisted_token_admin.clone());
+    StellarAssetClient::new(&env, &unlisted_token).mint(&buyer, &1_000);
+
+    let result = client.try_create_escrow(&buyer, &seller, &unlisted_token, &100, &9_000);
+    assert_eq!(result, Err(Ok(EscrowError::TokenNotAllowed)));
+}


### PR DESCRIPTION
## Summary

Closes #539
Closes #544
Closes #570

---

### Issue #539 — escrow: unit tests for `create_escrow`

Added `contracts/escrow/tests/create_test.rs` with 6 tests:

- **happy path**: creates escrow and verifies all stored fields (buyer, seller, token, amount, status, expiration)
- **zero amount**: `create_escrow` with `amount = 0` returns `InvalidAmount`
- **negative amount**: `amount = -1` returns `InvalidAmount`
- **expired expiration**: expiration ≤ current ledger timestamp returns `InvalidExpiration`
- **buyer == seller**: same address for both parties returns `InvalidRecipient`
- **non-whitelisted token**: token not in whitelist returns `TokenNotAllowed`

### Issue #544 — certificates: unit tests for `init`

Added `contracts/certificates/tests/init_tests.rs` with 3 tests:

- **sets state**: `init` completes without error and contract is not paused afterward
- **double init rejected**: second call to `init` returns `AlreadyInitialized`
- **auth required**: `init` records the admin address as the authorizing principal

Registered `init_tests` in `contracts/certificates/Cargo.toml`.

### Issue #570 — chainverse-core: `transfer_admin` emits ADM_CHNG event

`transfer_admin` in `contracts/chainverse-core/src/lib.rs` (line 176) already publishes:

```rust
env.events().publish((symbol_short!("ADM_CHNG"),), (old_admin, new_admin));
```

A test `test_transfer_admin_emits_adm_chng_event` in `src/test.rs` confirms it. No code change needed.

### CI workflow fixes

- Removed the **`STELLAR_SECRET_KEY` identity setup step** — unit tests run locally and don't need a network identity; this was blocking forks from running CI
- Moved `cargo fmt` and `cargo clippy` to `working-directory: contracts` so they operate on the correct workspace
- Dropped `--target wasm32-unknown-unknown` from `clippy` — that flag suppresses test-only code paths and caused false negatives

## What was tested

- All new test files follow the same patterns as existing tests in those contracts
- `transfer_admin` ADM_CHNG event is verified by the pre-existing test suite