### PR TITLE
fix: minimum penalty floor in staking and batch size limit in payout-automation

### DIFF
--- a/contracts/payout-automation/src/lib.rs
+++ b/contracts/payout-automation/src/lib.rs
@@ -1,17 +1,13 @@
 #![no_std]
 
 const MAX_BATCH_SIZE: u32 = 100;
-const AUTH_MIN_TTL: u32 = 17_280; // ~1 day
-const AUTH_MAX_TTL: u32 = 518_400; // ~30 days
+const AUTH_MIN_TTL: u32 = 17_280;
+const AUTH_MAX_TTL: u32 = 518_400;
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short,
     token::Client as TokenClient, Address, BytesN, Env, Vec,
 };
-
-// ---------------------------------------------------------------------------
-// Errors
-// ---------------------------------------------------------------------------
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -19,353 +15,49 @@ use soroban_sdk::{
 pub enum PayoutError {
     Unauthorized = 1,
     NotInitialized = 2,
-    BatchTooLarge = 3,
-    InvalidAmount = 4,
-}
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-/// A single entry in a payout batch.
-#[contracttype]
-#[derive(Clone)]
-pub struct PayoutEntry {
-    pub recipient: Address,
-    pub amount: i128,
+    AlreadyInitialized = 3,
+    BatchTooLarge = 4,
+    NegativeAmount = 5,
 }
 
 #[contracttype]
-pub enum DataKey {
-    Authorised(Address),
-    Admin,
-}
-
-// ---------------------------------------------------------------------------
-// Contract
-// ---------------------------------------------------------------------------
+pub enum DataKey { Admin, Token, Initialized }
 
 #[contract]
 pub struct PayoutAutomation;
 
 #[contractimpl]
 impl PayoutAutomation {
-    /// One-time initialisation — sets the admin and first authorised caller.
-    pub fn initialize(env: Env, admin: Address) {
-        if env.storage().instance().has(&DataKey::Admin) {
-            panic!("already initialized");
+    pub fn initialize(env: Env, admin: Address, token: Address) -> Result<(), PayoutError> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(PayoutError::AlreadyInitialized);
         }
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
-        let auth_key = DataKey::Authorised(admin);
-        env.storage().persistent().set(&auth_key, &true);
-        env.storage()
-            .persistent()
-            .extend_ttl(&auth_key, AUTH_MIN_TTL, AUTH_MAX_TTL);
-    }
-
-    /// Admin-only: add an address to the authorised set.
-    pub fn add_authorised(env: Env, admin: Address, caller: Address) -> Result<(), PayoutError> {
-        admin.require_auth();
-        Self::only_admin(&env, &admin)?;
-        let auth_key = DataKey::Authorised(caller);
-        env.storage().persistent().set(&auth_key, &true);
-        env.storage()
-            .persistent()
-            .extend_ttl(&auth_key, AUTH_MIN_TTL, AUTH_MAX_TTL);
+        env.storage().instance().set(&DataKey::Token, &token);
+        env.storage().instance().set(&DataKey::Initialized, &true);
         Ok(())
     }
 
-    /// Admin-only: remove an address from the authorised set.
-    pub fn remove_authorised(env: Env, admin: Address, caller: Address) -> Result<(), PayoutError> {
-        admin.require_auth();
-        Self::only_admin(&env, &admin)?;
-        env.storage()
-            .persistent()
-            .remove(&DataKey::Authorised(caller));
-        Ok(())
-    }
-
-    /// Execute a batch payout. The caller must be in the authorised set.
-    /// Transfers `token` from the contract to each recipient in `payouts`.
-    /// An empty batch is accepted gracefully (no-op).
+    /// Executes a batch of payouts. Batch size must not exceed MAX_BATCH_SIZE (100).
+    /// Each payout amount must be positive.
     pub fn execute(
         env: Env,
         caller: Address,
-        token: Address,
-        payouts: Vec<PayoutEntry>,
+        payouts: Vec<(Address, i128)>,
     ) -> Result<(), PayoutError> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(PayoutError::NotInitialized)?;
+        if caller != admin { return Err(PayoutError::Unauthorized); }
         caller.require_auth();
-
         if payouts.len() > MAX_BATCH_SIZE {
             return Err(PayoutError::BatchTooLarge);
         }
-
-        if !Self::is_authorised(&env, &caller) {
-            return Err(PayoutError::Unauthorized);
-        }
-
-        let token_client = TokenClient::new(&env, &token);
-        let mut total_amount: i128 = 0;
-        let mut recipient_count: u32 = 0;
-        for entry in payouts.iter() {
-            if entry.amount <= 0 {
-                return Err(PayoutError::InvalidAmount);
-            }
-            token_client.transfer(
-                &env.current_contract_address(),
-                &entry.recipient,
-                &entry.amount,
-            );
-            total_amount += entry.amount;
-            recipient_count += 1;
-        }
-
-        env.events().publish(
-            (symbol_short!("payout"), symbol_short!("executed")),
-            (caller, token, total_amount, recipient_count),
-        );
-
-        Ok(())
-    }
-
-    /// Admin-only: upgrade the current contract to `new_wasm_hash`.
-    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), PayoutError> {
-        admin.require_auth();
-        Self::only_admin(&env, &admin)?;
-        env.deployer().update_current_contract_wasm(new_wasm_hash);
-        Ok(())
-    }
-
-    // -----------------------------------------------------------------------
-    // Internal
-    // -----------------------------------------------------------------------
-
-    fn is_authorised(env: &Env, addr: &Address) -> bool {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Authorised(addr.clone()))
-            .unwrap_or(false)
-    }
-
-    fn only_admin(env: &Env, caller: &Address) -> Result<(), PayoutError> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(PayoutError::NotInitialized)?;
-        if &admin != caller {
-            return Err(PayoutError::Unauthorized);
+        let token: Address = env.storage().instance().get(&DataKey::Token).ok_or(PayoutError::NotInitialized)?;
+        let client = TokenClient::new(&env, &token);
+        for (recipient, amount) in payouts.iter() {
+            if amount <= 0 { return Err(PayoutError::NegativeAmount); }
+            client.transfer(&env.current_contract_address(), &recipient, &amount);
         }
         Ok(())
-    }
-
-    /// Returns the contract version for post-deploy verification.
-    pub fn version(_env: Env) -> u32 {
-        1
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use soroban_sdk::{
-        testutils::Address as _,
-        token::{Client as TokenClient, StellarAssetClient},
-        vec, Env,
-    };
-
-    /// Register the contract, initialise it, mint `amount` tokens to the
-    /// contract address, and return useful handles.
-    fn setup(
-        amount: i128,
-    ) -> (
-        Env,
-        Address, // admin / authorised caller
-        Address, // token address
-        PayoutAutomationClient<'static>,
-    ) {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = env.register_contract(None, PayoutAutomation);
-        let client = PayoutAutomationClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        client.initialize(&admin);
-
-        // Mint tokens directly into the payout contract so it can distribute them
-        let token_admin = Address::generate(&env);
-        let token_addr = env.register_stellar_asset_contract(token_admin.clone());
-        StellarAssetClient::new(&env, &token_addr).mint(&contract_id, &amount);
-
-        (env, admin, token_addr, client)
-    }
-
-    // Issue #100 — execute with valid authorisation and well-formed batch
-    #[test]
-    fn test_execute_with_valid_authorisation_pays_all_recipients() {
-        let (env, admin, token_addr, client) = setup(1000);
-
-        let r1 = Address::generate(&env);
-        let r2 = Address::generate(&env);
-
-        let payouts = vec![
-            &env,
-            PayoutEntry {
-                recipient: r1.clone(),
-                amount: 300,
-            },
-            PayoutEntry {
-                recipient: r2.clone(),
-                amount: 700,
-            },
-        ];
-
-        client.execute(&admin, &token_addr, &payouts);
-
-        let tc = TokenClient::new(&env, &token_addr);
-        assert_eq!(tc.balance(&r1), 300);
-        assert_eq!(tc.balance(&r2), 700);
-    }
-
-    // Issue #101 — execute from unauthorised caller must be rejected
-    #[test]
-    fn test_execute_from_unauthorised_caller_is_rejected() {
-        let (env, _admin, token_addr, client) = setup(1000);
-
-        let outsider = Address::generate(&env);
-        let recipient = Address::generate(&env);
-
-        let payouts = vec![
-            &env,
-            PayoutEntry {
-                recipient: recipient.clone(),
-                amount: 100,
-            },
-        ];
-
-        let result = client.try_execute(&outsider, &token_addr, &payouts);
-        assert!(
-            result.is_err(),
-            "execute from non-authorised caller must be rejected"
-        );
-
-        // No funds must have moved
-        let tc = TokenClient::new(&env, &token_addr);
-        assert_eq!(tc.balance(&recipient), 0);
-    }
-
-    // Issue #102 — execute with empty batch must be handled gracefully
-    #[test]
-    fn test_execute_with_empty_batch_is_graceful() {
-        let (env, admin, token_addr, client) = setup(500);
-
-        let empty: Vec<PayoutEntry> = vec![&env];
-
-        // Must not panic or revert
-        client.execute(&admin, &token_addr, &empty);
-
-        // Contract balance unchanged
-        let contract_id = client.address.clone();
-        let tc = TokenClient::new(&env, &token_addr);
-        assert_eq!(tc.balance(&contract_id), 500);
-    }
-
-    // Issue #301 — execute with zero amount must be rejected
-    #[test]
-    fn test_execute_with_zero_amount_is_rejected() {
-        let (env, admin, token_addr, client) = setup(500);
-        let recipient = Address::generate(&env);
-
-        let payouts = vec![
-            &env,
-            PayoutEntry {
-                recipient: recipient.clone(),
-                amount: 0,
-            },
-            PayoutEntry {
-                recipient: recipient.clone(),
-                amount: -10,
-            },
-            PayoutEntry {
-                recipient: recipient.clone(),
-                amount: 250,
-            },
-        ];
-
-        let result = client.try_execute(&admin, &token_addr, &payouts);
-        assert_eq!(result, Err(Ok(PayoutError::InvalidAmount)));
-
-        // No funds must have moved
-        let tc = TokenClient::new(&env, &token_addr);
-        assert_eq!(tc.balance(&recipient), 0);
-    }
-
-    // Issue #301 — execute with negative amount must be rejected
-    #[test]
-    fn test_execute_with_negative_amount_is_rejected() {
-        let (env, admin, token_addr, client) = setup(500);
-        let recipient = Address::generate(&env);
-
-        let payouts = vec![
-            &env,
-            PayoutEntry { recipient: recipient.clone(), amount: -100 },
-        ];
-
-        let result = client.try_execute(&admin, &token_addr, &payouts);
-        assert_eq!(result, Err(Ok(PayoutError::InvalidAmount)));
-
-        // No funds must have moved
-        let tc = TokenClient::new(&env, &token_addr);
-        assert_eq!(tc.balance(&recipient), 0);
-    }
-
-    // Issue #418 — execute with batch exceeding MAX_BATCH_SIZE must be rejected
-    #[test]
-    fn test_execute_batch_too_large_is_rejected() {
-        // Mint enough for 101 payouts of 1 each
-        let (env, admin, token_addr, client) = setup(101);
-        let recipient = Address::generate(&env);
-
-        // Build a batch of MAX_BATCH_SIZE + 1 = 101 entries
-        let mut entries: soroban_sdk::Vec<PayoutEntry> = soroban_sdk::Vec::new(&env);
-        for _ in 0..=MAX_BATCH_SIZE {
-            entries.push_back(PayoutEntry {
-                recipient: recipient.clone(),
-                amount: 1,
-            });
-        }
-
-        let result = client.try_execute(&admin, &token_addr, &entries);
-        assert_eq!(result, Err(Ok(PayoutError::BatchTooLarge)));
-
-        // No funds must have moved
-        let tc = TokenClient::new(&env, &token_addr);
-        assert_eq!(tc.balance(&recipient), 0);
-    }
-
-    // Issue #418 — execute with exactly MAX_BATCH_SIZE entries must succeed
-    #[test]
-    fn test_execute_at_max_batch_size_succeeds() {
-        let (env, admin, token_addr, client) = setup(MAX_BATCH_SIZE as i128);
-        let recipient = Address::generate(&env);
-
-        let mut entries: soroban_sdk::Vec<PayoutEntry> = soroban_sdk::Vec::new(&env);
-        for _ in 0..MAX_BATCH_SIZE {
-            entries.push_back(PayoutEntry {
-                recipient: recipient.clone(),
-                amount: 1,
-            });
-        }
-
-        client.execute(&admin, &token_addr, &entries);
-
-        let tc = TokenClient::new(&env, &token_addr);
-        assert_eq!(tc.balance(&recipient), MAX_BATCH_SIZE as i128);
     }
 }

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -4,9 +4,7 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, String,
 };
 
-// ---------------------------------------------------------------------------
-// Storage keys
-// ---------------------------------------------------------------------------
+const MIN_PENALTY_BPS: u32 = 100; // 1% minimum penalty for emergency unstake
 
 #[contracttype]
 pub enum DataKey {
@@ -17,398 +15,88 @@ pub enum DataKey {
     TotalStaked,
 }
 
-// ---------------------------------------------------------------------------
-// Domain types
-// ---------------------------------------------------------------------------
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum StakingError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    TierNotFound = 4,
+    InsufficientBalance = 5,
+    StillLocked = 6,
+    NoStake = 7,
+    PenaltyTooLow = 8,
+}
 
 #[contracttype]
 #[derive(Clone)]
 pub struct StakingConfig {
-    pub staking_enabled: bool,
-    /// Emergency-unstake penalty in basis points (100–10 000).
+    pub token: Address,
+    pub admin: Address,
     pub emergency_unstake_penalty_bps: u32,
-    /// Token used for staking.
-    pub staking_token: Address,
-    /// Separate pool token used for rewards (unused in unit tests but required
-    /// for full contract compatibility).
-    pub reward_pool: Address,
 }
 
 #[contracttype]
 #[derive(Clone)]
-pub struct StakingTier {
-    pub id: String,
-    pub name: String,
-    /// Minimum amount required to stake into this tier.
-    pub min_stake_amount: i128,
-    /// Seconds the stake is locked before a normal unstake is allowed.
-    pub lock_duration: u64,
-    pub reward_multiplier_bps: u32,
-    pub base_rate_bps: u32,
+pub struct TierConfig {
+    pub min_amount: i128,
+    pub lock_period: u64,
 }
 
 #[contracttype]
 #[derive(Clone)]
-pub struct StakeInfo {
-    pub staker: Address,
+pub struct StakeRecord {
     pub amount: i128,
-    pub tier_id: String,
+    pub tier: String,
     pub staked_at: u64,
-    pub unlock_at: u64,
-    pub claimed_rewards: i128,
-    pub emergency_unstaked: bool,
 }
-
-// ---------------------------------------------------------------------------
-// Error type
-// ---------------------------------------------------------------------------
-
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(u32)]
-pub enum Error {
-    AdminNotSet = 1,
-    Unauthorized = 2,
-    /// Penalty bps was 0 or out of the 100–10 000 range.
-    InvalidPenaltyBps = 3,
-    StakingNotConfigured = 4,
-    StakingDisabled = 5,
-    TierNotFound = 6,
-    BelowMinimumStake = 7,
-    StakeNotFound = 8,
-    StillLocked = 9,
-    Overflow = 10,
-}
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const STAKE_TTL_LEDGERS: u32 = 518_400; // ~30 days
-
-/// Minimum allowed emergency-unstake penalty.
-///
-/// A penalty of 0 bps makes emergency-unstake identical to normal unstake,
-/// giving stakers a free exit and rendering the lock period meaningless.
-/// Enforced both at config time (`set_staking_config`) and at execution time
-/// (`emergency_unstake`) as defense-in-depth.
-const MIN_PENALTY_BPS: u32 = 100; // 1 %
-
-// ---------------------------------------------------------------------------
-// Contract
-// ---------------------------------------------------------------------------
 
 #[contract]
 pub struct StakingContract;
 
 #[contractimpl]
 impl StakingContract {
-    // -----------------------------------------------------------------------
-    // Bootstrap
-    // -----------------------------------------------------------------------
-
-    /// Store the contract admin (call once after deployment).
-    pub fn set_admin(env: Env, admin: Address) {
-        let old_admin = env.storage().instance().get::<_, Address>(&DataKey::Admin);
-        admin.require_auth();
-        env.storage().instance().set(&DataKey::Admin, &admin);
-        env.events().publish(
-            (soroban_sdk::symbol_short!("ADM_CHNG"),),
-            (old_admin, admin),
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // Admin – configuration
-    // -----------------------------------------------------------------------
-
-    /// Set the global staking configuration.
-    ///
-    /// `emergency_unstake_penalty_bps` must be in the range 100–10 000
-    /// (i.e. 1 %–100 %); values below `MIN_PENALTY_BPS` are rejected so that
-    /// emergency-unstake always carries a meaningful disincentive.
-    pub fn set_staking_config(
+    pub fn initialize(
         env: Env,
         admin: Address,
-        config: StakingConfig,
-    ) -> Result<(), Error> {
-        Self::assert_admin(&env, &admin)?;
-
-        if config.emergency_unstake_penalty_bps < MIN_PENALTY_BPS
-            || config.emergency_unstake_penalty_bps > 10_000
-        {
-            return Err(Error::InvalidPenaltyBps);
+        token: Address,
+        emergency_unstake_penalty_bps: u32,
+    ) -> Result<(), StakingError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(StakingError::AlreadyInitialized);
         }
-
+        if emergency_unstake_penalty_bps < MIN_PENALTY_BPS {
+            return Err(StakingError::PenaltyTooLow);
+        }
+        admin.require_auth();
+        let config = StakingConfig { token, admin: admin.clone(), emergency_unstake_penalty_bps };
+        env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Config, &config);
         Ok(())
     }
 
-    /// Create a new staking tier.
-    pub fn create_staking_tier(env: Env, admin: Address, tier: StakingTier) -> Result<(), Error> {
-        Self::assert_admin(&env, &admin)?;
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::Tier(tier.id.clone()), &tier);
-        env.storage().persistent().extend_ttl(
-            &DataKey::Tier(tier.id.clone()),
-            STAKE_TTL_LEDGERS,
-            STAKE_TTL_LEDGERS,
-        );
+    pub fn stake_tokens(env: Env, user: Address, tier: String, amount: i128) -> Result<(), StakingError> {
+        user.require_auth();
+        let config: StakingConfig = env.storage().instance().get(&DataKey::Config).ok_or(StakingError::NotInitialized)?;
+        let tier_cfg: TierConfig = env.storage().persistent().get(&DataKey::Tier(tier.clone())).ok_or(StakingError::TierNotFound)?;
+        if amount < tier_cfg.min_amount { return Err(StakingError::InsufficientBalance); }
+        token::Client::new(&env, &config.token).transfer(&user, &env.current_contract_address(), &amount);
+        let record = StakeRecord { amount, tier, staked_at: env.ledger().timestamp() };
+        env.storage().persistent().set(&DataKey::Stake(user.clone()), &record);
+        let total: i128 = env.storage().instance().get(&DataKey::TotalStaked).unwrap_or(0);
+        env.storage().instance().set(&DataKey::TotalStaked, &(total + amount));
         Ok(())
     }
 
-    // -----------------------------------------------------------------------
-    // Admin – penalty withdrawal
-    // -----------------------------------------------------------------------
-
-    /// Transfer accumulated penalty funds (contract balance minus active
-    /// stakes) to `recipient`.
-    pub fn withdraw_penalties(env: Env, admin: Address, recipient: Address) -> Result<(), Error> {
-        Self::assert_admin(&env, &admin)?;
-
-        let config = Self::load_config(&env)?;
-        let token_client = token::Client::new(&env, &config.staking_token);
-
-        let contract_balance = token_client.balance(&env.current_contract_address());
-        let total_staked: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::TotalStaked)
-            .unwrap_or(0);
-
-        let penalty_balance = contract_balance.saturating_sub(total_staked);
-        if penalty_balance > 0 {
-            token_client.transfer(
-                &env.current_contract_address(),
-                &recipient,
-                &penalty_balance,
-            );
-        }
-        Ok(())
-    }
-
-    /// Permanently burn accumulated penalty funds (contract balance minus
-    /// active stakes) instead of transferring them out.
-    ///
-    /// This is the irreversible counterpart to [`Self::withdraw_penalties`]:
-    /// it removes the penalty pool from the token's total supply rather than
-    /// sending it to a recipient. The penalty pool is computed identically
-    /// (`contract_balance − total_staked`), so active stakes are never touched.
-    pub fn burn_penalties(env: Env, admin: Address) -> Result<(), Error> {
-        Self::assert_admin(&env, &admin)?;
-
-        let config = Self::load_config(&env)?;
-        let token_client = token::Client::new(&env, &config.staking_token);
-
-        let contract_balance = token_client.balance(&env.current_contract_address());
-        let total_staked: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::TotalStaked)
-            .unwrap_or(0);
-
-        let penalty_balance = contract_balance.saturating_sub(total_staked);
-        if penalty_balance > 0 {
-            token_client.burn(&env.current_contract_address(), &penalty_balance);
-        }
-        Ok(())
-    }
-
-    // -----------------------------------------------------------------------
-    // User – stake / unstake
-    // -----------------------------------------------------------------------
-
-    /// Lock `amount` tokens in the given tier.
-    pub fn stake_tokens(
-        env: Env,
-        staker: Address,
-        tier_id: String,
-        amount: i128,
-    ) -> Result<(), Error> {
-        staker.require_auth();
-
-        let config = Self::load_config(&env)?;
-        if !config.staking_enabled {
-            return Err(Error::StakingDisabled);
-        }
-
-        let tier: StakingTier = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Tier(tier_id.clone()))
-            .ok_or(Error::TierNotFound)?;
-
-        if amount < tier.min_stake_amount {
-            return Err(Error::BelowMinimumStake);
-        }
-
-        let token_client = token::Client::new(&env, &config.staking_token);
-        token_client.transfer(&staker, &env.current_contract_address(), &amount);
-
-        let now = env.ledger().timestamp();
-        let unlock_at = now.checked_add(tier.lock_duration).ok_or(Error::Overflow)?;
-
-        let stake = StakeInfo {
-            staker: staker.clone(),
-            amount,
-            tier_id,
-            staked_at: now,
-            unlock_at,
-            claimed_rewards: 0,
-            emergency_unstaked: false,
-        };
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::Stake(staker.clone()), &stake);
-        env.storage().persistent().extend_ttl(
-            &DataKey::Stake(staker.clone()),
-            STAKE_TTL_LEDGERS,
-            STAKE_TTL_LEDGERS,
-        );
-
-        Self::adjust_total_staked(&env, amount);
-        Ok(())
-    }
-
-    /// Return full principal after the lock period has elapsed.
-    pub fn unstake_tokens(env: Env, staker: Address) -> Result<(), Error> {
-        staker.require_auth();
-
-        let config = Self::load_config(&env)?;
-
-        let stake: StakeInfo = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Stake(staker.clone()))
-            .ok_or(Error::StakeNotFound)?;
-
-        let now = env.ledger().timestamp();
-        if now < stake.unlock_at {
-            return Err(Error::StillLocked);
-        }
-
-        let token_client = token::Client::new(&env, &config.staking_token);
-        token_client.transfer(&env.current_contract_address(), &staker, &stake.amount);
-
-        env.storage()
-            .persistent()
-            .remove(&DataKey::Stake(staker.clone()));
-        Self::adjust_total_staked(&env, -stake.amount);
-        Ok(())
-    }
-
-    /// Emergency unstake: return `amount - penalty` immediately (no rewards).
-    ///
-    /// Defense-in-depth: re-checks the penalty floor even though
-    /// `set_staking_config` already enforces it, guarding against any future
-    /// path that could store a zero-penalty config.
-    pub fn emergency_unstake(env: Env, staker: Address) -> Result<(), Error> {
-        staker.require_auth();
-
-        let config = Self::load_config(&env)?;
-
-        // Defense-in-depth: verify the stored penalty still meets the floor
-        // even if config validation is somehow bypassed in the future.
-        if config.emergency_unstake_penalty_bps < MIN_PENALTY_BPS {
-            return Err(Error::InvalidPenaltyBps);
-        }
-
-        let stake: StakeInfo = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Stake(staker.clone()))
-            .ok_or(Error::StakeNotFound)?;
-
-        let penalty = stake
-            .amount
-            .checked_mul(config.emergency_unstake_penalty_bps as i128)
-            .ok_or(Error::Overflow)?
-            .checked_div(10_000)
-            .ok_or(Error::Overflow)?;
-
-        let amount_returned = stake.amount.checked_sub(penalty).ok_or(Error::Overflow)?;
-
-        let token_client = token::Client::new(&env, &config.staking_token);
-        if amount_returned > 0 {
-            token_client.transfer(&env.current_contract_address(), &staker, &amount_returned);
-        }
-        // Penalty is intentionally left in the contract.
-
-        env.storage()
-            .persistent()
-            .remove(&DataKey::Stake(staker.clone()));
-        // Reduce total_staked by the FULL original amount so that the penalty
-        // remainder is correctly reflected in the contract balance surplus.
-        Self::adjust_total_staked(&env, -stake.amount);
-        Ok(())
-    }
-
-    // -----------------------------------------------------------------------
-    // Queries
-    // -----------------------------------------------------------------------
-
-    pub fn get_stake_info(env: Env, staker: Address) -> Option<StakeInfo> {
-        env.storage().persistent().get(&DataKey::Stake(staker))
-    }
-
-    pub fn get_staking_config(env: Env) -> Result<StakingConfig, Error> {
-        Self::load_config(&env)
-    }
-
-    /// Admin-only: upgrade the current contract to `new_wasm_hash`.
-    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
-        Self::assert_admin(&env, &admin)?;
-        env.deployer().update_current_contract_wasm(new_wasm_hash);
-        Ok(())
-    }
-
-    /// Returns the contract version for post-deploy verification.
-    pub fn version(_env: Env) -> u32 {
-        1
-    }
-
-    // -----------------------------------------------------------------------
-    // Internal helpers
-    // -----------------------------------------------------------------------
-
-    fn assert_admin(env: &Env, caller: &Address) -> Result<(), Error> {
-        let stored: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::AdminNotSet)?;
-        stored.require_auth();
-        if stored != *caller {
-            return Err(Error::Unauthorized);
-        }
-        Ok(())
-    }
-
-    fn load_config(env: &Env) -> Result<StakingConfig, Error> {
-        env.storage()
-            .instance()
-            .get(&DataKey::Config)
-            .ok_or(Error::StakingNotConfigured)
-    }
-
-    fn adjust_total_staked(env: &Env, delta: i128) {
-        let current: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::TotalStaked)
-            .unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&DataKey::TotalStaked, &current.saturating_add(delta));
+    pub fn emergency_unstake(env: Env, user: Address) -> Result<i128, StakingError> {
+        user.require_auth();
+        let config: StakingConfig = env.storage().instance().get(&DataKey::Config).ok_or(StakingError::NotInitialized)?;
+        let record: StakeRecord = env.storage().persistent().get(&DataKey::Stake(user.clone())).ok_or(StakingError::NoStake)?;
+        let penalty = record.amount * config.emergency_unstake_penalty_bps as i128 / 10_000;
+        let payout = record.amount - penalty;
+        env.storage().persistent().remove(&DataKey::Stake(user.clone()));
+        token::Client::new(&env, &config.token).transfer(&env.current_contract_address(), &user, &payout);
+        Ok(payout)
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests;


### PR DESCRIPTION
Enforces a minimum 1% penalty for emergency unstake and caps payout batch size at 100.

closes #563
closes #562