### PR TITLE
fix: stellar.toml, TTL extension, self-approve guard, event emission (#639-642)

### DIFF
--- a/.well-known/stellar.toml
+++ b/.well-known/stellar.toml
@@ -1,0 +1,4 @@
+VERSION = "2.0.0"
+NETWORK_PASSPHRASE = "Public Global Stellar Network ; September 2015"
+
+[[ACCOUNTS]]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -12,6 +12,8 @@ members = [
     "chv_token",
     "shared",
     "common",
+    "staking",
+    "token",
 ]
 
 [workspace.dependencies]

--- a/contracts/chv_token/src/lib.rs
+++ b/contracts/chv_token/src/lib.rs
@@ -51,7 +51,9 @@ impl CHVToken {
         let to_bal: i128 = env.storage().persistent()
             .get(&DataKey::Balance(to.clone())).unwrap_or(0);
         env.storage().persistent().set(&DataKey::Balance(from.clone()), &(from_bal - amount));
+        env.storage().persistent().extend_ttl(&DataKey::Balance(from.clone()), BALANCE_MIN_TTL, BALANCE_MAX_TTL);
         env.storage().persistent().set(&DataKey::Balance(to.clone()), &(to_bal + amount));
+        env.storage().persistent().extend_ttl(&DataKey::Balance(to.clone()), BALANCE_MIN_TTL, BALANCE_MAX_TTL);
         env.events().publish((symbol_short!("TRANSFER"),), (from, to, amount));
         Ok(())
     }

--- a/contracts/escrow-vault/src/lib.rs
+++ b/contracts/escrow-vault/src/lib.rs
@@ -3,7 +3,7 @@
 const VAULT_MIN_TTL: u32 = 100_000;
 const VAULT_MAX_TTL: u32 = 500_000;
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Vec};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -37,7 +37,6 @@ pub struct Vault {
 
 #[contracttype]
 pub enum DataKey { Vault(BytesN<32>), VaultCount }
-pub enum DataKey { Vault(BytesN<32>) }
 
 #[contract]
 pub struct EscrowVault;
@@ -66,9 +65,6 @@ impl EscrowVault {
         if amount <= 0 {
             return Err(VaultError::InvalidAmount);
         }
-        if amount <= 0 {
-            return Err(VaultError::InvalidAmount);
-        }
         depositor.require_auth();
         soroban_sdk::token::Client::new(&env, &token)
             .transfer(&depositor, &env.current_contract_address(), &amount);
@@ -76,12 +72,50 @@ impl EscrowVault {
             &soroban_sdk::Bytes::from_slice(&env, &env.ledger().timestamp().to_be_bytes())
         ).into();
         let vault = Vault {
-            depositor, recipient, token, amount, approvers, approvals: 0, threshold, status: VaultStatus::Pending,
-            depositor, recipient, token, amount, approvers, approvals: 0, threshold,
+            depositor: depositor.clone(),
+            recipient,
+            token,
+            amount,
+            approvers,
+            approvals: 0,
+            threshold,
             status: VaultStatus::Pending,
         };
         env.storage().persistent().set(&DataKey::Vault(id.clone()), &vault);
         env.storage().persistent().extend_ttl(&DataKey::Vault(id.clone()), VAULT_MIN_TTL, VAULT_MAX_TTL);
+        // #639 — emit event for audit trail
+        env.events().publish((symbol_short!("VAULT_NEW"),), (id.clone(), depositor.clone(), amount));
         Ok(id)
+    }
+
+    pub fn approve(
+        env: Env,
+        caller: Address,
+        id: BytesN<32>,
+    ) -> Result<(), VaultError> {
+        caller.require_auth();
+        let mut vault: Vault = env.storage().persistent()
+            .get(&DataKey::Vault(id.clone()))
+            .ok_or(VaultError::NotFound)?;
+        match vault.status {
+            VaultStatus::Pending => {}
+            _ => return Err(VaultError::NotPending),
+        }
+        // #640 — prevent depositor from self-approving their own vault release
+        if caller == vault.depositor && vault.approvers.contains(&caller) {
+            return Err(VaultError::Unauthorized);
+        }
+        if !vault.approvers.contains(&caller) {
+            return Err(VaultError::Unauthorized);
+        }
+        vault.approvals += 1;
+        if vault.approvals >= vault.threshold {
+            vault.status = VaultStatus::Released;
+            soroban_sdk::token::Client::new(&env, &vault.token)
+                .transfer(&env.current_contract_address(), &vault.recipient, &vault.amount);
+        }
+        env.storage().persistent().set(&DataKey::Vault(id.clone()), &vault);
+        env.storage().persistent().extend_ttl(&DataKey::Vault(id.clone()), VAULT_MIN_TTL, VAULT_MAX_TTL);
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Closes #642 — .well-known/stellar.toml and Cargo workspace verified/added
- Closes #641 — persistent storage entries now extend TTL after every set() call
- Closes #640 — approve() rejects depositor self-approving their own vault release
- Closes #639 — create_vault emits VAULT_NEW event for audit trail