### PR TITLE
reward: configurable amount + batch claim; escrow: index lookups + guarded dispute

### DIFF
--- a/contracts/chainverse-core/src/escrow/mod.rs
+++ b/contracts/chainverse-core/src/escrow/mod.rs
@@ -43,6 +43,10 @@ pub enum EscrowKey {
     Record(u64),
     /// Monotonically increasing counter used to generate new ids.
     NextId,
+    /// Maps a depositor (buyer) → the ids of their escrows.
+    BuyerIndex(Address),
+    /// Maps a recipient (seller) → the ids of their escrows.
+    SellerIndex(Address),
 }
 
 // ---------------------------------------------------------------------------
@@ -71,6 +75,22 @@ fn load(env: &Env, id: u64) -> Result<EscrowRecord, ContractError> {
 fn save(env: &Env, record: &EscrowRecord) {
     let key = EscrowKey::Record(record.id);
     env.storage().persistent().set(&key, record);
+    env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL);
+}
+
+fn add_to_buyer_index(env: &Env, buyer: &Address, id: u64) {
+    let key = EscrowKey::BuyerIndex(buyer.clone());
+    let mut ids: Vec<u64> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+    ids.push_back(id);
+    env.storage().persistent().set(&key, &ids);
+    env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL);
+}
+
+fn add_to_seller_index(env: &Env, seller: &Address, id: u64) {
+    let key = EscrowKey::SellerIndex(seller.clone());
+    let mut ids: Vec<u64> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+    ids.push_back(id);
+    env.storage().persistent().set(&key, &ids);
     env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL);
 }
 
@@ -107,6 +127,8 @@ pub fn create(
         expires_at,
     };
     save(env, &record);
+    add_to_buyer_index(env, &record.depositor, id);
+    add_to_seller_index(env, &record.recipient, id);
     Ok(id)
 }
 
@@ -163,40 +185,42 @@ pub fn get(env: &Env, id: u64) -> Result<EscrowRecord, ContractError> {
     load(env, id)
 }
 
-/// Returns all escrows where `buyer` is the depositor.
+/// Returns escrows where `buyer` is the depositor, reading a per-buyer index
+/// instead of scanning every escrow. Cost scales with the buyer's own escrow
+/// count and the `limit`, not with the global escrow count (fixes the O(n) DoS).
 pub fn get_by_buyer(env: &Env, buyer: &Address, start: u64, limit: u64) -> Vec<EscrowRecord> {
-    let mut results = Vec::new(env);
-    let count: u64 = env
+    let ids: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&EscrowKey::NextId)
-        .unwrap_or(0u64);
-    let end = core::cmp::min(count, start.saturating_add(limit));
-    for i in start..end {
-        if let Ok(record) = load(env, i) {
-            if &record.depositor == buyer {
-                results.push_back(record);
-            }
-        }
-    }
-    results
+        .get(&EscrowKey::BuyerIndex(buyer.clone()))
+        .unwrap_or(Vec::new(env));
+    collect_by_ids(env, &ids, start, limit)
 }
 
-/// Returns all escrows where `seller` is the recipient.
+/// Returns escrows where `seller` is the recipient, reading a per-seller index
+/// instead of scanning every escrow.
 pub fn get_by_seller(env: &Env, seller: &Address, start: u64, limit: u64) -> Vec<EscrowRecord> {
-    let mut results = Vec::new(env);
-    let count: u64 = env
+    let ids: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&EscrowKey::NextId)
-        .unwrap_or(0u64);
-    let end = core::cmp::min(count, start.saturating_add(limit));
-    for i in start..end {
-        if let Ok(record) = load(env, i) {
-            if &record.recipient == seller {
+        .get(&EscrowKey::SellerIndex(seller.clone()))
+        .unwrap_or(Vec::new(env));
+    collect_by_ids(env, &ids, start, limit)
+}
+
+/// Load the escrow records for a paginated slice of an id index.
+fn collect_by_ids(env: &Env, ids: &Vec<u64>, start: u64, limit: u64) -> Vec<EscrowRecord> {
+    let mut results = Vec::new(env);
+    let total = ids.len() as u64;
+    let end = core::cmp::min(total, start.saturating_add(limit));
+    let mut i = start;
+    while i < end {
+        if let Some(id) = ids.get(i as u32) {
+            if let Ok(record) = load(env, id) {
                 results.push_back(record);
             }
         }
+        i += 1;
     }
     results
 }

--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -1,0 +1,41 @@
+use crate::errors::EscrowError;
+use crate::storage::{load_escrow, save_escrow};
+use crate::types::EscrowStatus;
+use soroban_sdk::{Address, Env};
+
+/// Opens a dispute on an escrow.
+///
+/// State machine (dispute transition only):
+/// ```text
+///   Pending    --dispute-->  Disputed        (allowed)
+///   Completed  --dispute-->  Err(NotPending)  (already released — rejected)
+///   Cancelled  --dispute-->  Err(NotPending)  (already settled — rejected)
+///   Disputed   --dispute-->  Err(AlreadyDisputed)
+/// ```
+///
+/// Only the buyer may dispute, and only while the escrow is still `Pending`
+/// (funded). This prevents post-settlement disputes: a buyer who has already
+/// had funds released (status `Completed`) or refunded (`Cancelled`) can no
+/// longer flip a zero-balance escrow back to `Disputed` and corrupt its state.
+pub fn dispute(env: &Env, caller: Address, escrow_id: u64) -> Result<(), EscrowError> {
+    caller.require_auth();
+
+    let mut escrow = load_escrow(env, escrow_id).ok_or(EscrowError::NotFound)?;
+
+    if caller != escrow.buyer {
+        return Err(EscrowError::Unauthorized);
+    }
+
+    if escrow.status == EscrowStatus::Disputed {
+        return Err(EscrowError::AlreadyDisputed);
+    }
+
+    // Reject disputes on any escrow that is no longer funded.
+    if escrow.status != EscrowStatus::Pending {
+        return Err(EscrowError::NotPending);
+    }
+
+    escrow.status = EscrowStatus::Disputed;
+    save_escrow(env, escrow_id, &escrow);
+    Ok(())
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 mod create;
+mod dispute;
 mod errors;
 mod events;
 mod refund;
@@ -65,6 +66,13 @@ impl EscrowContract {
     /// Refunds the buyer after expiry. Only callable after the expiration timestamp.
     pub fn refund_escrow(env: Env, caller: Address, escrow_id: u64) -> Result<(), EscrowError> {
         refund::refund_escrow(&env, caller, escrow_id)
+    }
+
+    /// Opens a dispute on a still-funded escrow. Only the buyer may dispute, and
+    /// only while the escrow is `Pending` — a released or cancelled escrow can
+    /// no longer be disputed, preventing post-settlement state corruption.
+    pub fn dispute_escrow(env: Env, caller: Address, escrow_id: u64) -> Result<(), EscrowError> {
+        dispute::dispute(&env, caller, escrow_id)
     }
 
     /// Returns the escrow record for the given ID, if it exists.

--- a/contracts/reward/src/lib.rs
+++ b/contracts/reward/src/lib.rs
@@ -95,6 +95,24 @@ impl RewardContract {
         reward::claim_reward(env, user)
     }
 
+    /// Admin-only: update the per-student reward amount without redeploying.
+    pub fn set_reward_amount(env: Env, new_amount: i128) -> Result<(), errors::Error> {
+        reward::update_reward_amount(env, new_amount)
+    }
+
+    /// Returns the current per-student reward amount.
+    pub fn get_reward_amount(env: Env) -> Result<i128, errors::Error> {
+        reward::current_reward_amount(env)
+    }
+
+    /// Admin-only: distribute rewards to many students in a single transaction.
+    pub fn batch_claim_reward(
+        env: Env,
+        recipients: soroban_sdk::Vec<Address>,
+    ) -> Result<(), errors::Error> {
+        reward::batch_claim_reward(env, recipients)
+    }
+
     /// Accumulate a penalty when a user emergency-unstakes.
     ///
     /// Called internally by the staking logic; the penalty amount is credited

--- a/contracts/reward/src/reward.rs
+++ b/contracts/reward/src/reward.rs
@@ -1,7 +1,54 @@
-use soroban_sdk::{Env, Address, token::Client};
+use soroban_sdk::{symbol_short, token::Client, Address, Env, Vec};
 use crate::storage::*;
 use crate::events::*;
 use crate::errors::Error;
+
+/// Maximum number of recipients per batch, to stay within the Soroban compute
+/// budget for a single transaction.
+const MAX_BATCH: u32 = 50;
+
+/// Admin-only: update the per-student reward amount for all subsequent claims.
+/// The reward amount is stored (not hardcoded), so the admin can adjust it as
+/// the token value changes without redeploying the contract.
+pub fn update_reward_amount(env: Env, new_amount: i128) -> Result<(), Error> {
+    crate::admin::require_admin(&env)?;
+    if new_amount <= 0 {
+        panic!("reward amount must be positive");
+    }
+    crate::storage::set_reward_amount(&env, new_amount);
+    env.events()
+        .publish((symbol_short!("reward_upd"),), new_amount);
+    Ok(())
+}
+
+/// Returns the current per-student reward amount.
+pub fn current_reward_amount(env: Env) -> Result<i128, Error> {
+    crate::storage::get_reward_amount(&env)
+}
+
+/// Admin-only: distribute the reward to many students in one transaction.
+/// Already-rewarded students in the batch are skipped silently (no error, no
+/// double reward). Batches larger than `MAX_BATCH` are rejected.
+pub fn batch_claim_reward(env: Env, recipients: Vec<Address>) -> Result<(), Error> {
+    crate::admin::require_admin(&env)?;
+    if recipients.len() > MAX_BATCH {
+        panic!("batch too large");
+    }
+
+    let treasury = get_treasury(&env)?;
+    let token_address = get_token(&env)?;
+    let amount_per = get_reward_amount(&env)?;
+    let token_client = Client::new(&env, &token_address);
+
+    for student in recipients.iter() {
+        if !has_been_rewarded(&env, &student) {
+            set_rewarded(&env, &student);
+            token_client.transfer(&treasury, &student, &amount_per);
+            emit_reward_claimed(&env, &student, amount_per);
+        }
+    }
+    Ok(())
+}
 
 pub fn claim_reward(env: Env, user: Address) -> Result<(), Error> {
     user.require_auth();


### PR DESCRIPTION
Small, focused fixes for two reward features and two escrow bugs.

## reward: configurable reward amount (#726)
Adds `set_reward_amount` (admin-only, rejects non-positive) and `get_reward_amount` so the per-student reward can be updated without redeploying. The amount is already stored, so subsequent claims pick up the new value. Emits a `reward_upd` event.

## reward: batch_claim_reward (#725)
Adds `batch_claim_reward(recipients)` (admin-only) to distribute rewards to a whole cohort in one transaction. Caps the batch at 50 to stay within the compute budget and silently skips already-rewarded students (no error, no double reward).

## escrow: O(n) get_by_buyer / get_by_seller (#711)
`get_by_buyer` / `get_by_seller` in `chainverse-core` previously scanned every escrow up to `NextId`. They now read a per-address index (`BuyerIndex` / `SellerIndex`) populated on escrow creation, so lookup cost scales with the caller's own escrows and the page `limit`, not the global escrow count.

## escrow: dispute after settlement (#710)
`contracts/escrow` had a `Disputed` status but no guarded transition. Adds a `dispute_escrow` entrypoint that only allows a **buyer** to dispute a **`Pending`** (funded) escrow — a `Completed` (released) or `Cancelled` escrow returns `NotPending`, preventing post-settlement disputes that would corrupt a zero-balance escrow. The state machine is documented in the module.

## Closes

- closes #726
- closes #725
- closes #711
- closes #710
