### PR TITLE
feat/fix: escrow partial release + state machine, vault approval guards

### DIFF
--- a/contracts/escrow-vault/src/lib.rs
+++ b/contracts/escrow-vault/src/lib.rs
@@ -18,6 +18,8 @@ pub enum VaultError {
     InvalidAmount = 7,
     AlreadyInitialized = 8,
     NotInitialized = 9,
+    ConflictOfInterest = 10,
+    NotVoted = 11,
 }
 
 #[contracttype]
@@ -86,6 +88,11 @@ impl EscrowVault {
                 }
             }
         }
+        // #716 — a conflicted party (depositor/buyer or recipient/beneficiary)
+        // must not be an approver, otherwise the multisig can be self-approved.
+        if approvers.contains(&depositor) || approvers.contains(&recipient) {
+            return Err(VaultError::ConflictOfInterest);
+        }
         if amount <= 0 {
             return Err(VaultError::InvalidAmount);
         }
@@ -125,19 +132,48 @@ impl EscrowVault {
             VaultStatus::Pending => {}
             _ => return Err(VaultError::NotPending),
         }
-        // #640 — prevent depositor from self-approving their own vault release
-        if caller == vault.depositor && vault.approvers.contains(&caller) {
-            return Err(VaultError::Unauthorized);
+        // #716 — no conflicted party (depositor/buyer or recipient/beneficiary)
+        // may approve, even if listed as an approver.
+        if caller == vault.depositor || caller == vault.recipient {
+            return Err(VaultError::ConflictOfInterest);
         }
         if !vault.approvers.contains(&caller) {
             return Err(VaultError::Unauthorized);
         }
+        // #718 — record the individual vote so it can be revoked; block double votes.
+        let voted_key = VotedKey::Voted(id.clone(), caller.clone());
+        if env.storage().persistent().has(&voted_key) {
+            return Err(VaultError::AlreadyVoted);
+        }
+        env.storage().persistent().set(&voted_key, &true);
         vault.approvals += 1;
         if vault.approvals >= vault.threshold {
             vault.status = VaultStatus::Released;
             soroban_sdk::token::Client::new(&env, &vault.token)
                 .transfer(&env.current_contract_address(), &vault.recipient, &vault.amount);
         }
+        env.storage().persistent().set(&DataKey::Vault(id.clone()), &vault);
+        env.storage().persistent().extend_ttl(&DataKey::Vault(id.clone()), VAULT_MIN_TTL, VAULT_MAX_TTL);
+        Ok(())
+    }
+
+    /// #718 — an approver revokes their prior approval before the threshold is
+    /// met. Fails once the vault has been released or cancelled.
+    pub fn revoke_approval(env: Env, caller: Address, id: BytesN<32>) -> Result<(), VaultError> {
+        caller.require_auth();
+        let mut vault: Vault = env.storage().persistent()
+            .get(&DataKey::Vault(id.clone()))
+            .ok_or(VaultError::NotFound)?;
+        match vault.status {
+            VaultStatus::Pending => {}
+            _ => return Err(VaultError::NotPending),
+        }
+        let voted_key = VotedKey::Voted(id.clone(), caller.clone());
+        if !env.storage().persistent().has(&voted_key) {
+            return Err(VaultError::NotVoted);
+        }
+        env.storage().persistent().remove(&voted_key);
+        vault.approvals = vault.approvals.saturating_sub(1);
         env.storage().persistent().set(&DataKey::Vault(id.clone()), &vault);
         env.storage().persistent().extend_ttl(&DataKey::Vault(id.clone()), VAULT_MIN_TTL, VAULT_MAX_TTL);
         Ok(())

--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -25,6 +25,9 @@ pub fn dispute_escrow(env: &Env, caller: Address, escrow_id: u64) -> Result<(), 
         return Err(EscrowError::NotPending);
     }
 
+    // #714 — validate the status transition before writing it.
+    crate::escrow_state::assert_transition_allowed(&escrow.status, &EscrowStatus::Disputed)?;
+
     escrow.status = EscrowStatus::Disputed;
     save_escrow(env, escrow_id, &escrow);
     Ok(())

--- a/contracts/escrow/src/escrow_state.rs
+++ b/contracts/escrow/src/escrow_state.rs
@@ -1,0 +1,34 @@
+use crate::errors::EscrowError;
+use crate::types::EscrowStatus;
+
+/// #714 — single source of truth for allowed escrow status transitions.
+///
+/// Every status-changing function should call this before writing a new
+/// status, so adding a new transition only requires updating the map below.
+pub fn assert_transition_allowed(
+    from: &EscrowStatus,
+    to: &EscrowStatus,
+) -> Result<(), EscrowError> {
+    let allowed: &[EscrowStatus] = match from {
+        EscrowStatus::Created => &[EscrowStatus::Funded, EscrowStatus::Cancelled],
+        EscrowStatus::Funded => &[
+            EscrowStatus::Completed,
+            EscrowStatus::Cancelled,
+            EscrowStatus::Disputed,
+        ],
+        EscrowStatus::Pending => &[
+            EscrowStatus::Completed,
+            EscrowStatus::Cancelled,
+            EscrowStatus::Disputed,
+        ],
+        EscrowStatus::Disputed => &[EscrowStatus::Completed, EscrowStatus::Cancelled],
+        // Completed / Cancelled are terminal.
+        _ => &[],
+    };
+
+    if allowed.contains(to) {
+        Ok(())
+    } else {
+        Err(EscrowError::InvalidEscrowState)
+    }
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -3,6 +3,7 @@
 mod create;
 mod dispute;
 mod errors;
+mod escrow_state;
 mod events;
 mod fund;
 mod refund;

--- a/contracts/escrow/src/refund.rs
+++ b/contracts/escrow/src/refund.rs
@@ -31,6 +31,9 @@ pub fn refund_escrow(env: &Env, caller: Address, escrow_id: u64) -> Result<(), E
         &escrow.amount,
     );
 
+    // #714 — validate the status transition before writing it.
+    crate::escrow_state::assert_transition_allowed(&escrow.status, &EscrowStatus::Cancelled)?;
+
     let refunded = escrow.amount;
     escrow.status = EscrowStatus::Cancelled;
     escrow.amount = 0;


### PR DESCRIPTION
Small, focused changes to the escrow and escrow-vault contracts.

closes #713
closes #714
closes #716
closes #718

## #714 — escrow: state-machine module
Adds `contracts/escrow/src/escrow_state.rs` with a single `assert_transition_allowed(from, to)` allowed-transitions map covering the contract's current statuses (`Created → Funded/Cancelled`, `Funded → Completed/Cancelled/Disputed`, `Pending → Completed/Cancelled/Disputed`, `Disputed → Completed/Cancelled`). It's now called from `refund` and `dispute` before a new status is written, so adding a new transition only requires updating the map. Reuses the existing `InvalidEscrowState` error.

## #716 — escrow-vault: block conflicted approvers
A conflicted party (depositor/buyer or recipient/beneficiary) can no longer approve a release — enforced both at vault creation (the approver list is rejected) and in `approve()` — via a new `ConflictOfInterest` error.

## #718 — escrow-vault: `revoke_approval()`
Adds `revoke_approval(vault_id, approver)` so an approver can withdraw their approval while the vault is still `Pending`; it fails once released/cancelled. To support this, `approve()` now records each individual vote (using the existing `VotedKey`), so approvals can be revoked and double-voting is blocked with `AlreadyVoted`.

## #713 — escrow: `partial_release`
Already present on `main` (the escrow contract gained `partial_release(caller, escrow_id, amount)` in a recent merge), so this PR does not re-add it. Its acceptance criteria are satisfied by the existing implementation, which this branch builds on top of.

## Notes on scope
The issues' example snippets assumed a slightly different data model (e.g. an `arbiter`/`remaining_amount` on escrow, a `beneficiary` field, and a list-based `approvals` on the vault). I adapted each change to the contracts' **actual** fields and status enums. I did not run tests or a build locally. Separately, the escrow `release.rs` on `main` currently contains a duplicate `release_escrow` definition from an earlier merge — that pre-existing issue is out of scope here and worth a dedicated cleanup.
