### PR TITLE
fix: Add root-level Cargo workspace configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,31 @@
-[package]
-name = "chainverse_onchain"
-version = "0.1.0"
-edition = "2021"
+[workspace]
+resolver = "2"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
+members = [
+    "contracts/chv_token",
+    "contracts/payment",
+    "contracts/certificates",
+    "contracts/escrow",
+    "contracts/escrow-vault",
+    "contracts/reward",
+    "contracts/payout-automation",
+    "contracts/chainverse-core",
+    "contracts/chainverse-types",
+    "contracts/course_registry",
+    "contracts/shared",
+    "contracts/common",
+    "contracts/staking",
+    "contracts/token",
+]
 
-[dependencies]
-soroban-sdk = "20.0.0"
+[workspace.dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
 
 [profile.release]
-opt-level = "z"
+opt-level      = "z"
 overflow-checks = true
+debug          = 0
+strip          = "symbols"
+panic          = "abort"
+codegen-units  = 1
+lto            = true


### PR DESCRIPTION
Fixes #743 

# Pull Request

# Problem
There was no root-level `Cargo.toml` with `[workspace]` that lists all contracts as members. This caused several issues:
- Running `stellar contract build` from the root failed to discover contracts
- `cargo test --workspace` didn't work
- `cargo build --workspace` couldn't build all contracts together

## Solution
Created a root-level `Cargo.toml` workspace configuration that:
- Uses resolver version 2 for better dependency resolution
- Lists all 14 contract and crate members in the workspace
- Defines shared workspace dependencies (soroban-sdk 21.0.0 with testutils)
- Configures optimized release profile for WASM builds

## Changes
- **Modified**: `Cargo.toml` - Converted from package configuration to workspace configuration
- Added workspace members:
  - `contracts/chv_token`
  - `contracts/payment`
  - `contracts/certificates` (nft_certificate)
  - `contracts/escrow`
  - `contracts/escrow-vault`
  - `contracts/reward`
  - `contracts/payout-automation`
  - `contracts/chainverse-core`
  - `contracts/chainverse-types`
  - `contracts/course_registry`
  - `contracts/shared`
  - `contracts/common`
  - `contracts/staking`
  - `contracts/token`

## Acceptance Criteria
✅ `cargo build --workspace --target wasm32-unknown-unknown --release` builds all contracts  
✅ `cargo test --workspace` runs all tests across all contracts  
✅ `stellar contract build` from repo root discovers and builds all contracts  

## Testing Instructions
```bash
# Build all contracts
cargo build --workspace --target wasm32-unknown-unknown --release

# Run all tests
cargo test --workspace

# Build with stellar CLI
stellar contract build
```